### PR TITLE
[FEAT] 메뉴 옵션 UI 구현 (#4)

### DIFF
--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		059C45762CEE10D800FB00DC /* MenuOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45752CEE10D800FB00DC /* MenuOption.swift */; };
 		059C45782CEE113D00FB00DC /* MenuOptionSectionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45772CEE113D00FB00DC /* MenuOptionSectionType.swift */; };
 		059C457A2CEE16A200FB00DC /* MenuOptionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45792CEE16A200FB00DC /* MenuOptionHeaderView.swift */; };
+		059C457E2CEE18EF00FB00DC /* MenuOptionShotCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C457D2CEE18EF00FB00DC /* MenuOptionShotCell.swift */; };
 		742A43CA2CE8918600535185 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43C92CE8918600535185 /* SnapKit */; };
 		742A43CF2CE8919300535185 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CE2CE8919300535185 /* Then */; };
 /* End PBXBuildFile section */
@@ -67,6 +68,7 @@
 		059C45752CEE10D800FB00DC /* MenuOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOption.swift; sourceTree = "<group>"; };
 		059C45772CEE113D00FB00DC /* MenuOptionSectionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionSectionType.swift; sourceTree = "<group>"; };
 		059C45792CEE16A200FB00DC /* MenuOptionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionHeaderView.swift; sourceTree = "<group>"; };
+		059C457D2CEE18EF00FB00DC /* MenuOptionShotCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionShotCell.swift; sourceTree = "<group>"; };
 		742A43942CE88EA700535185 /* TWOSOMEHEART-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TWOSOMEHEART-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -258,6 +260,7 @@
 		059C456E2CEE0F6600FB00DC /* TableViewCell */ = {
 			isa = PBXGroup;
 			children = (
+				059C457D2CEE18EF00FB00DC /* MenuOptionShotCell.swift */,
 			);
 			path = TableViewCell;
 			sourceTree = "<group>";
@@ -399,6 +402,7 @@
 				059C455E2CEE0B5A00FB00DC /* BaseNavViewController.swift in Sources */,
 				059C455F2CEE0B5A00FB00DC /* BaseViewController.swift in Sources */,
 				059C45602CEE0B5A00FB00DC /* ViewController.swift in Sources */,
+				059C457E2CEE18EF00FB00DC /* MenuOptionShotCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		059C45872CEE1A9F00FB00DC /* MenuOptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45862CEE1A9F00FB00DC /* MenuOptionViewController.swift */; };
 		059C45892CEE1BBB00FB00DC /* CounterViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45882CEE1BBB00FB00DC /* CounterViewDelegate.swift */; };
 		059C46412CEF383A00FB00DC /* Aliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C46402CEF383A00FB00DC /* Aliases.swift */; };
+		059C46432CEF406900FB00DC /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C46422CEF406900FB00DC /* BaseView.swift */; };
 		742A43CA2CE8918600535185 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43C92CE8918600535185 /* SnapKit */; };
 		742A43CF2CE8919300535185 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CE2CE8919300535185 /* Then */; };
 /* End PBXBuildFile section */
@@ -81,6 +82,7 @@
 		059C45862CEE1A9F00FB00DC /* MenuOptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionViewController.swift; sourceTree = "<group>"; };
 		059C45882CEE1BBB00FB00DC /* CounterViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterViewDelegate.swift; sourceTree = "<group>"; };
 		059C46402CEF383A00FB00DC /* Aliases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Aliases.swift; sourceTree = "<group>"; };
+		059C46422CEF406900FB00DC /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
 		742A43942CE88EA700535185 /* TWOSOMEHEART-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TWOSOMEHEART-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -184,6 +186,7 @@
 			isa = PBXGroup;
 			children = (
 				059C45492CEE0B5A00FB00DC /* BaseNavViewController.swift */,
+				059C46422CEF406900FB00DC /* BaseView.swift */,
 				059C454A2CEE0B5A00FB00DC /* BaseViewController.swift */,
 				059C45712CEE0F9B00FB00DC /* BaseTableViewCell.swift */,
 			);
@@ -425,6 +428,7 @@
 				059C455E2CEE0B5A00FB00DC /* BaseNavViewController.swift in Sources */,
 				059C455F2CEE0B5A00FB00DC /* BaseViewController.swift in Sources */,
 				059C45602CEE0B5A00FB00DC /* ViewController.swift in Sources */,
+				059C46432CEF406900FB00DC /* BaseView.swift in Sources */,
 				059C45852CEE1A3700FB00DC /* MenuOptionDrizzleCell.swift in Sources */,
 				059C457E2CEE18EF00FB00DC /* MenuOptionShotCell.swift in Sources */,
 			);

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		059C45852CEE1A3700FB00DC /* MenuOptionDrizzleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45842CEE1A3700FB00DC /* MenuOptionDrizzleCell.swift */; };
 		059C45872CEE1A9F00FB00DC /* MenuOptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45862CEE1A9F00FB00DC /* MenuOptionViewController.swift */; };
 		059C45892CEE1BBB00FB00DC /* CounterViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45882CEE1BBB00FB00DC /* CounterViewDelegate.swift */; };
+		059C46412CEF383A00FB00DC /* Aliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C46402CEF383A00FB00DC /* Aliases.swift */; };
 		742A43CA2CE8918600535185 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43C92CE8918600535185 /* SnapKit */; };
 		742A43CF2CE8919300535185 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CE2CE8919300535185 /* Then */; };
 /* End PBXBuildFile section */
@@ -79,6 +80,7 @@
 		059C45842CEE1A3700FB00DC /* MenuOptionDrizzleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionDrizzleCell.swift; sourceTree = "<group>"; };
 		059C45862CEE1A9F00FB00DC /* MenuOptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionViewController.swift; sourceTree = "<group>"; };
 		059C45882CEE1BBB00FB00DC /* CounterViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterViewDelegate.swift; sourceTree = "<group>"; };
+		059C46402CEF383A00FB00DC /* Aliases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Aliases.swift; sourceTree = "<group>"; };
 		742A43942CE88EA700535185 /* TWOSOMEHEART-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TWOSOMEHEART-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -160,6 +162,7 @@
 			isa = PBXGroup;
 			children = (
 				059C45442CEE0B5A00FB00DC /* Enums */,
+				059C46402CEF383A00FB00DC /* Aliases.swift */,
 				059C45452CEE0B5A00FB00DC /* ScreenUtils.swift */,
 				059C45462CEE0B5A00FB00DC /* StringLiterals.swift */,
 			);
@@ -397,6 +400,7 @@
 			files = (
 				059C45512CEE0B5A00FB00DC /* AppDelegate.swift in Sources */,
 				059C45522CEE0B5A00FB00DC /* SceneDelegate.swift in Sources */,
+				059C46412CEF383A00FB00DC /* Aliases.swift in Sources */,
 				059C45892CEE1BBB00FB00DC /* CounterViewDelegate.swift in Sources */,
 				059C45782CEE113D00FB00DC /* MenuOptionSectionType.swift in Sources */,
 				059C45682CEE0E6600FB00DC /* ReusableIdentifier+.swift in Sources */,

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		059C45722CEE0F9B00FB00DC /* BaseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45712CEE0F9B00FB00DC /* BaseTableViewCell.swift */; };
 		059C45742CEE107700FB00DC /* MenuOptionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45732CEE107700FB00DC /* MenuOptionHeader.swift */; };
 		059C45762CEE10D800FB00DC /* MenuOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45752CEE10D800FB00DC /* MenuOption.swift */; };
+		059C45782CEE113D00FB00DC /* MenuOptionSectionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45772CEE113D00FB00DC /* MenuOptionSectionType.swift */; };
 		742A43CA2CE8918600535185 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43C92CE8918600535185 /* SnapKit */; };
 		742A43CF2CE8919300535185 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CE2CE8919300535185 /* Then */; };
 /* End PBXBuildFile section */
@@ -63,6 +64,7 @@
 		059C45712CEE0F9B00FB00DC /* BaseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewCell.swift; sourceTree = "<group>"; };
 		059C45732CEE107700FB00DC /* MenuOptionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionHeader.swift; sourceTree = "<group>"; };
 		059C45752CEE10D800FB00DC /* MenuOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOption.swift; sourceTree = "<group>"; };
+		059C45772CEE113D00FB00DC /* MenuOptionSectionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionSectionType.swift; sourceTree = "<group>"; };
 		742A43942CE88EA700535185 /* TWOSOMEHEART-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TWOSOMEHEART-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -238,6 +240,7 @@
 		059C456C2CEE0F5900FB00DC /* Type */ = {
 			isa = PBXGroup;
 			children = (
+				059C45772CEE113D00FB00DC /* MenuOptionSectionType.swift */,
 			);
 			path = Type;
 			sourceTree = "<group>";
@@ -373,6 +376,7 @@
 			files = (
 				059C45512CEE0B5A00FB00DC /* AppDelegate.swift in Sources */,
 				059C45522CEE0B5A00FB00DC /* SceneDelegate.swift in Sources */,
+				059C45782CEE113D00FB00DC /* MenuOptionSectionType.swift in Sources */,
 				059C45682CEE0E6600FB00DC /* ReusableIdentifier+.swift in Sources */,
 				059C45532CEE0B5A00FB00DC /* String+.swift in Sources */,
 				059C45722CEE0F9B00FB00DC /* BaseTableViewCell.swift in Sources */,

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		059C45642CEE0B5A00FB00DC /* AppleSDGothicNeo-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 059C45392CEE0B5A00FB00DC /* AppleSDGothicNeo-Regular.ttf */; };
 		059C45652CEE0B5A00FB00DC /* AppleSDGothicNeo-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 059C453A2CEE0B5A00FB00DC /* AppleSDGothicNeo-SemiBold.ttf */; };
 		059C45662CEE0B5A00FB00DC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 059C453D2CEE0B5A00FB00DC /* Assets.xcassets */; };
+		059C45682CEE0E6600FB00DC /* ReusableIdentifier+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45672CEE0E6600FB00DC /* ReusableIdentifier+.swift */; };
 		742A43CA2CE8918600535185 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43C92CE8918600535185 /* SnapKit */; };
 		742A43CF2CE8919300535185 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CE2CE8919300535185 /* Then */; };
 /* End PBXBuildFile section */
@@ -55,6 +56,7 @@
 		059C45492CEE0B5A00FB00DC /* BaseNavViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseNavViewController.swift; sourceTree = "<group>"; };
 		059C454A2CEE0B5A00FB00DC /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		059C454C2CEE0B5A00FB00DC /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		059C45672CEE0E6600FB00DC /* ReusableIdentifier+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReusableIdentifier+.swift"; sourceTree = "<group>"; };
 		742A43942CE88EA700535185 /* TWOSOMEHEART-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TWOSOMEHEART-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -89,6 +91,7 @@
 				059C45342CEE0B5A00FB00DC /* UILabel+.swift */,
 				059C45352CEE0B5A00FB00DC /* UIStackView+.swift */,
 				059C45362CEE0B5A00FB00DC /* UIView+.swift */,
+				059C45672CEE0E6600FB00DC /* ReusableIdentifier+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -297,6 +300,7 @@
 			files = (
 				059C45512CEE0B5A00FB00DC /* AppDelegate.swift in Sources */,
 				059C45522CEE0B5A00FB00DC /* SceneDelegate.swift in Sources */,
+				059C45682CEE0E6600FB00DC /* ReusableIdentifier+.swift in Sources */,
 				059C45532CEE0B5A00FB00DC /* String+.swift in Sources */,
 				059C45542CEE0B5A00FB00DC /* UILabel+.swift in Sources */,
 				059C45552CEE0B5A00FB00DC /* UIStackView+.swift in Sources */,

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		059C45662CEE0B5A00FB00DC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 059C453D2CEE0B5A00FB00DC /* Assets.xcassets */; };
 		059C45682CEE0E6600FB00DC /* ReusableIdentifier+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45672CEE0E6600FB00DC /* ReusableIdentifier+.swift */; };
 		059C45722CEE0F9B00FB00DC /* BaseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45712CEE0F9B00FB00DC /* BaseTableViewCell.swift */; };
+		059C45742CEE107700FB00DC /* MenuOptionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45732CEE107700FB00DC /* MenuOptionHeader.swift */; };
 		742A43CA2CE8918600535185 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43C92CE8918600535185 /* SnapKit */; };
 		742A43CF2CE8919300535185 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CE2CE8919300535185 /* Then */; };
 /* End PBXBuildFile section */
@@ -59,6 +60,7 @@
 		059C454C2CEE0B5A00FB00DC /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		059C45672CEE0E6600FB00DC /* ReusableIdentifier+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReusableIdentifier+.swift"; sourceTree = "<group>"; };
 		059C45712CEE0F9B00FB00DC /* BaseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewCell.swift; sourceTree = "<group>"; };
+		059C45732CEE107700FB00DC /* MenuOptionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionHeader.swift; sourceTree = "<group>"; };
 		742A43942CE88EA700535185 /* TWOSOMEHEART-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TWOSOMEHEART-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -186,6 +188,7 @@
 		059C454F2CEE0B5A00FB00DC /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				059C45692CEE0F3A00FB00DC /* MenuOption */,
 				059C454B2CEE0B5A00FB00DC /* Base */,
 				059C454E2CEE0B5A00FB00DC /* DummyView */,
 			);
@@ -200,6 +203,70 @@
 				059C454F2CEE0B5A00FB00DC /* Presentation */,
 			);
 			path = "TWOSOMEHEART-iOS";
+			sourceTree = "<group>";
+		};
+		059C45692CEE0F3A00FB00DC /* MenuOption */ = {
+			isa = PBXGroup;
+			children = (
+				059C45702CEE0F7D00FB00DC /* Protocol */,
+				059C456F2CEE0F7400FB00DC /* Model */,
+				059C456B2CEE0F5100FB00DC /* View */,
+				059C456A2CEE0F4A00FB00DC /* Controller */,
+			);
+			path = MenuOption;
+			sourceTree = "<group>";
+		};
+		059C456A2CEE0F4A00FB00DC /* Controller */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Controller;
+			sourceTree = "<group>";
+		};
+		059C456B2CEE0F5100FB00DC /* View */ = {
+			isa = PBXGroup;
+			children = (
+				059C456C2CEE0F5900FB00DC /* Type */,
+				059C456D2CEE0F6000FB00DC /* HeaderView */,
+				059C456E2CEE0F6600FB00DC /* TableViewCell */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		059C456C2CEE0F5900FB00DC /* Type */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Type;
+			sourceTree = "<group>";
+		};
+		059C456D2CEE0F6000FB00DC /* HeaderView */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = HeaderView;
+			sourceTree = "<group>";
+		};
+		059C456E2CEE0F6600FB00DC /* TableViewCell */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = TableViewCell;
+			sourceTree = "<group>";
+		};
+		059C456F2CEE0F7400FB00DC /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				059C45732CEE107700FB00DC /* MenuOptionHeader.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		059C45702CEE0F7D00FB00DC /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		742A438B2CE88EA700535185 = {
@@ -310,6 +377,7 @@
 				059C45552CEE0B5A00FB00DC /* UIStackView+.swift in Sources */,
 				059C45562CEE0B5A00FB00DC /* UIView+.swift in Sources */,
 				059C45572CEE0B5A00FB00DC /* TSFont.swift in Sources */,
+				059C45742CEE107700FB00DC /* MenuOptionHeader.swift in Sources */,
 				059C45582CEE0B5A00FB00DC /* CounterView.swift in Sources */,
 				059C45592CEE0B5A00FB00DC /* CustomSegmentControlView.swift in Sources */,
 				059C455A2CEE0B5A00FB00DC /* CounterType.swift in Sources */,

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
@@ -35,10 +35,10 @@
 		059C45782CEE113D00FB00DC /* MenuOptionSectionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45772CEE113D00FB00DC /* MenuOptionSectionType.swift */; };
 		059C457A2CEE16A200FB00DC /* MenuOptionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45792CEE16A200FB00DC /* MenuOptionHeaderView.swift */; };
 		059C457E2CEE18EF00FB00DC /* MenuOptionShotCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C457D2CEE18EF00FB00DC /* MenuOptionShotCell.swift */; };
-		059C457F2CEE198300FB00DC /* SnapKit-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CB2CE8918600535185 /* SnapKit-Dynamic */; };
 		059C45812CEE199300FB00DC /* MenuOptionSyrupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45802CEE199300FB00DC /* MenuOptionSyrupCell.swift */; };
 		059C45832CEE19EA00FB00DC /* MenuOptionWhippedCreamCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45822CEE19EA00FB00DC /* MenuOptionWhippedCreamCell.swift */; };
 		059C45852CEE1A3700FB00DC /* MenuOptionDrizzleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45842CEE1A3700FB00DC /* MenuOptionDrizzleCell.swift */; };
+		059C45892CEE1BBB00FB00DC /* CounterViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45882CEE1BBB00FB00DC /* CounterViewDelegate.swift */; };
 		742A43CA2CE8918600535185 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43C92CE8918600535185 /* SnapKit */; };
 		742A43CF2CE8919300535185 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CE2CE8919300535185 /* Then */; };
 /* End PBXBuildFile section */
@@ -76,6 +76,7 @@
 		059C45802CEE199300FB00DC /* MenuOptionSyrupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionSyrupCell.swift; sourceTree = "<group>"; };
 		059C45822CEE19EA00FB00DC /* MenuOptionWhippedCreamCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionWhippedCreamCell.swift; sourceTree = "<group>"; };
 		059C45842CEE1A3700FB00DC /* MenuOptionDrizzleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionDrizzleCell.swift; sourceTree = "<group>"; };
+		059C45882CEE1BBB00FB00DC /* CounterViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterViewDelegate.swift; sourceTree = "<group>"; };
 		742A43942CE88EA700535185 /* TWOSOMEHEART-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TWOSOMEHEART-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -84,7 +85,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				059C457F2CEE198300FB00DC /* SnapKit-Dynamic in Frameworks */,
 				742A43CA2CE8918600535185 /* SnapKit in Frameworks */,
 				742A43CF2CE8919300535185 /* Then in Frameworks */,
 			);
@@ -288,6 +288,7 @@
 		059C45702CEE0F7D00FB00DC /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
+				059C45882CEE1BBB00FB00DC /* CounterViewDelegate.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -393,6 +394,7 @@
 			files = (
 				059C45512CEE0B5A00FB00DC /* AppDelegate.swift in Sources */,
 				059C45522CEE0B5A00FB00DC /* SceneDelegate.swift in Sources */,
+				059C45892CEE1BBB00FB00DC /* CounterViewDelegate.swift in Sources */,
 				059C45782CEE113D00FB00DC /* MenuOptionSectionType.swift in Sources */,
 				059C45682CEE0E6600FB00DC /* ReusableIdentifier+.swift in Sources */,
 				059C45532CEE0B5A00FB00DC /* String+.swift in Sources */,

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		059C45652CEE0B5A00FB00DC /* AppleSDGothicNeo-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 059C453A2CEE0B5A00FB00DC /* AppleSDGothicNeo-SemiBold.ttf */; };
 		059C45662CEE0B5A00FB00DC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 059C453D2CEE0B5A00FB00DC /* Assets.xcassets */; };
 		059C45682CEE0E6600FB00DC /* ReusableIdentifier+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45672CEE0E6600FB00DC /* ReusableIdentifier+.swift */; };
+		059C45722CEE0F9B00FB00DC /* BaseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45712CEE0F9B00FB00DC /* BaseTableViewCell.swift */; };
 		742A43CA2CE8918600535185 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43C92CE8918600535185 /* SnapKit */; };
 		742A43CF2CE8919300535185 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CE2CE8919300535185 /* Then */; };
 /* End PBXBuildFile section */
@@ -57,6 +58,7 @@
 		059C454A2CEE0B5A00FB00DC /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		059C454C2CEE0B5A00FB00DC /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		059C45672CEE0E6600FB00DC /* ReusableIdentifier+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReusableIdentifier+.swift"; sourceTree = "<group>"; };
+		059C45712CEE0F9B00FB00DC /* BaseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewCell.swift; sourceTree = "<group>"; };
 		742A43942CE88EA700535185 /* TWOSOMEHEART-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TWOSOMEHEART-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -160,6 +162,7 @@
 			children = (
 				059C45492CEE0B5A00FB00DC /* BaseNavViewController.swift */,
 				059C454A2CEE0B5A00FB00DC /* BaseViewController.swift */,
+				059C45712CEE0F9B00FB00DC /* BaseTableViewCell.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -302,6 +305,7 @@
 				059C45522CEE0B5A00FB00DC /* SceneDelegate.swift in Sources */,
 				059C45682CEE0E6600FB00DC /* ReusableIdentifier+.swift in Sources */,
 				059C45532CEE0B5A00FB00DC /* String+.swift in Sources */,
+				059C45722CEE0F9B00FB00DC /* BaseTableViewCell.swift in Sources */,
 				059C45542CEE0B5A00FB00DC /* UILabel+.swift in Sources */,
 				059C45552CEE0B5A00FB00DC /* UIStackView+.swift in Sources */,
 				059C45562CEE0B5A00FB00DC /* UIView+.swift in Sources */,

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
@@ -7,34 +7,56 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		059C45512CEE0B5A00FB00DC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C452D2CEE0B5A00FB00DC /* AppDelegate.swift */; };
+		059C45522CEE0B5A00FB00DC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45312CEE0B5A00FB00DC /* SceneDelegate.swift */; };
+		059C45532CEE0B5A00FB00DC /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45332CEE0B5A00FB00DC /* String+.swift */; };
+		059C45542CEE0B5A00FB00DC /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45342CEE0B5A00FB00DC /* UILabel+.swift */; };
+		059C45552CEE0B5A00FB00DC /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45352CEE0B5A00FB00DC /* UIStackView+.swift */; };
+		059C45562CEE0B5A00FB00DC /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45362CEE0B5A00FB00DC /* UIView+.swift */; };
+		059C45572CEE0B5A00FB00DC /* TSFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C453B2CEE0B5A00FB00DC /* TSFont.swift */; };
+		059C45582CEE0B5A00FB00DC /* CounterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C453F2CEE0B5A00FB00DC /* CounterView.swift */; };
+		059C45592CEE0B5A00FB00DC /* CustomSegmentControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45402CEE0B5A00FB00DC /* CustomSegmentControlView.swift */; };
+		059C455A2CEE0B5A00FB00DC /* CounterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45422CEE0B5A00FB00DC /* CounterType.swift */; };
+		059C455B2CEE0B5A00FB00DC /* SegmentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45432CEE0B5A00FB00DC /* SegmentType.swift */; };
+		059C455C2CEE0B5A00FB00DC /* ScreenUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45452CEE0B5A00FB00DC /* ScreenUtils.swift */; };
+		059C455D2CEE0B5A00FB00DC /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45462CEE0B5A00FB00DC /* StringLiterals.swift */; };
+		059C455E2CEE0B5A00FB00DC /* BaseNavViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45492CEE0B5A00FB00DC /* BaseNavViewController.swift */; };
+		059C455F2CEE0B5A00FB00DC /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C454A2CEE0B5A00FB00DC /* BaseViewController.swift */; };
+		059C45602CEE0B5A00FB00DC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C454C2CEE0B5A00FB00DC /* ViewController.swift */; };
+		059C45622CEE0B5A00FB00DC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 059C45302CEE0B5A00FB00DC /* LaunchScreen.storyboard */; };
+		059C45632CEE0B5A00FB00DC /* AppleSDGothicNeo-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 059C45382CEE0B5A00FB00DC /* AppleSDGothicNeo-Bold.ttf */; };
+		059C45642CEE0B5A00FB00DC /* AppleSDGothicNeo-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 059C45392CEE0B5A00FB00DC /* AppleSDGothicNeo-Regular.ttf */; };
+		059C45652CEE0B5A00FB00DC /* AppleSDGothicNeo-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 059C453A2CEE0B5A00FB00DC /* AppleSDGothicNeo-SemiBold.ttf */; };
+		059C45662CEE0B5A00FB00DC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 059C453D2CEE0B5A00FB00DC /* Assets.xcassets */; };
 		742A43CA2CE8918600535185 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43C92CE8918600535185 /* SnapKit */; };
 		742A43CF2CE8919300535185 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CE2CE8919300535185 /* Then */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		059C452D2CEE0B5A00FB00DC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		059C452E2CEE0B5A00FB00DC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		059C452F2CEE0B5A00FB00DC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		059C45312CEE0B5A00FB00DC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		059C45332CEE0B5A00FB00DC /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
+		059C45342CEE0B5A00FB00DC /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
+		059C45352CEE0B5A00FB00DC /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
+		059C45362CEE0B5A00FB00DC /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
+		059C45382CEE0B5A00FB00DC /* AppleSDGothicNeo-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "AppleSDGothicNeo-Bold.ttf"; sourceTree = "<group>"; };
+		059C45392CEE0B5A00FB00DC /* AppleSDGothicNeo-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "AppleSDGothicNeo-Regular.ttf"; sourceTree = "<group>"; };
+		059C453A2CEE0B5A00FB00DC /* AppleSDGothicNeo-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "AppleSDGothicNeo-SemiBold.ttf"; sourceTree = "<group>"; };
+		059C453B2CEE0B5A00FB00DC /* TSFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TSFont.swift; sourceTree = "<group>"; };
+		059C453D2CEE0B5A00FB00DC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		059C453F2CEE0B5A00FB00DC /* CounterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterView.swift; sourceTree = "<group>"; };
+		059C45402CEE0B5A00FB00DC /* CustomSegmentControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSegmentControlView.swift; sourceTree = "<group>"; };
+		059C45422CEE0B5A00FB00DC /* CounterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterType.swift; sourceTree = "<group>"; };
+		059C45432CEE0B5A00FB00DC /* SegmentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentType.swift; sourceTree = "<group>"; };
+		059C45452CEE0B5A00FB00DC /* ScreenUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenUtils.swift; sourceTree = "<group>"; };
+		059C45462CEE0B5A00FB00DC /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
+		059C45492CEE0B5A00FB00DC /* BaseNavViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseNavViewController.swift; sourceTree = "<group>"; };
+		059C454A2CEE0B5A00FB00DC /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		059C454C2CEE0B5A00FB00DC /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		742A43942CE88EA700535185 /* TWOSOMEHEART-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TWOSOMEHEART-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
-
-/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		742A43A62CE88EAA00535185 /* Exceptions for "TWOSOMEHEART-iOS" folder in "TWOSOMEHEART-iOS" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				Application/Info.plist,
-			);
-			target = 742A43932CE88EA700535185 /* TWOSOMEHEART-iOS */;
-		};
-/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
-
-/* Begin PBXFileSystemSynchronizedRootGroup section */
-		742A43962CE88EA700535185 /* TWOSOMEHEART-iOS */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				742A43A62CE88EAA00535185 /* Exceptions for "TWOSOMEHEART-iOS" folder in "TWOSOMEHEART-iOS" target */,
-			);
-			path = "TWOSOMEHEART-iOS";
-			sourceTree = "<group>";
-		};
-/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		742A43912CE88EA700535185 /* Frameworks */ = {
@@ -49,10 +71,135 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		059C45322CEE0B5A00FB00DC /* Application */ = {
+			isa = PBXGroup;
+			children = (
+				059C452D2CEE0B5A00FB00DC /* AppDelegate.swift */,
+				059C452E2CEE0B5A00FB00DC /* Info.plist */,
+				059C45302CEE0B5A00FB00DC /* LaunchScreen.storyboard */,
+				059C45312CEE0B5A00FB00DC /* SceneDelegate.swift */,
+			);
+			path = Application;
+			sourceTree = "<group>";
+		};
+		059C45372CEE0B5A00FB00DC /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				059C45332CEE0B5A00FB00DC /* String+.swift */,
+				059C45342CEE0B5A00FB00DC /* UILabel+.swift */,
+				059C45352CEE0B5A00FB00DC /* UIStackView+.swift */,
+				059C45362CEE0B5A00FB00DC /* UIView+.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		059C453C2CEE0B5A00FB00DC /* Fonts */ = {
+			isa = PBXGroup;
+			children = (
+				059C45382CEE0B5A00FB00DC /* AppleSDGothicNeo-Bold.ttf */,
+				059C45392CEE0B5A00FB00DC /* AppleSDGothicNeo-Regular.ttf */,
+				059C453A2CEE0B5A00FB00DC /* AppleSDGothicNeo-SemiBold.ttf */,
+				059C453B2CEE0B5A00FB00DC /* TSFont.swift */,
+			);
+			path = Fonts;
+			sourceTree = "<group>";
+		};
+		059C453E2CEE0B5A00FB00DC /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				059C453C2CEE0B5A00FB00DC /* Fonts */,
+				059C453D2CEE0B5A00FB00DC /* Assets.xcassets */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		059C45412CEE0B5A00FB00DC /* UIComponents */ = {
+			isa = PBXGroup;
+			children = (
+				059C453F2CEE0B5A00FB00DC /* CounterView.swift */,
+				059C45402CEE0B5A00FB00DC /* CustomSegmentControlView.swift */,
+			);
+			path = UIComponents;
+			sourceTree = "<group>";
+		};
+		059C45442CEE0B5A00FB00DC /* Enums */ = {
+			isa = PBXGroup;
+			children = (
+				059C45422CEE0B5A00FB00DC /* CounterType.swift */,
+				059C45432CEE0B5A00FB00DC /* SegmentType.swift */,
+			);
+			path = Enums;
+			sourceTree = "<group>";
+		};
+		059C45472CEE0B5A00FB00DC /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				059C45442CEE0B5A00FB00DC /* Enums */,
+				059C45452CEE0B5A00FB00DC /* ScreenUtils.swift */,
+				059C45462CEE0B5A00FB00DC /* StringLiterals.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		059C45482CEE0B5A00FB00DC /* Global */ = {
+			isa = PBXGroup;
+			children = (
+				059C45372CEE0B5A00FB00DC /* Extensions */,
+				059C453E2CEE0B5A00FB00DC /* Resources */,
+				059C45412CEE0B5A00FB00DC /* UIComponents */,
+				059C45472CEE0B5A00FB00DC /* Utils */,
+			);
+			path = Global;
+			sourceTree = "<group>";
+		};
+		059C454B2CEE0B5A00FB00DC /* Base */ = {
+			isa = PBXGroup;
+			children = (
+				059C45492CEE0B5A00FB00DC /* BaseNavViewController.swift */,
+				059C454A2CEE0B5A00FB00DC /* BaseViewController.swift */,
+			);
+			path = Base;
+			sourceTree = "<group>";
+		};
+		059C454D2CEE0B5A00FB00DC /* Controller */ = {
+			isa = PBXGroup;
+			children = (
+				059C454C2CEE0B5A00FB00DC /* ViewController.swift */,
+			);
+			path = Controller;
+			sourceTree = "<group>";
+		};
+		059C454E2CEE0B5A00FB00DC /* DummyView */ = {
+			isa = PBXGroup;
+			children = (
+				059C454D2CEE0B5A00FB00DC /* Controller */,
+			);
+			path = DummyView;
+			sourceTree = "<group>";
+		};
+		059C454F2CEE0B5A00FB00DC /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				059C454B2CEE0B5A00FB00DC /* Base */,
+				059C454E2CEE0B5A00FB00DC /* DummyView */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		059C45502CEE0B5A00FB00DC /* TWOSOMEHEART-iOS */ = {
+			isa = PBXGroup;
+			children = (
+				059C45322CEE0B5A00FB00DC /* Application */,
+				059C45482CEE0B5A00FB00DC /* Global */,
+				059C454F2CEE0B5A00FB00DC /* Presentation */,
+			);
+			path = "TWOSOMEHEART-iOS";
+			sourceTree = "<group>";
+		};
 		742A438B2CE88EA700535185 = {
 			isa = PBXGroup;
 			children = (
-				742A43962CE88EA700535185 /* TWOSOMEHEART-iOS */,
+				059C45502CEE0B5A00FB00DC /* TWOSOMEHEART-iOS */,
 				742A43952CE88EA700535185 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -79,9 +226,6 @@
 			buildRules = (
 			);
 			dependencies = (
-			);
-			fileSystemSynchronizedGroups = (
-				742A43962CE88EA700535185 /* TWOSOMEHEART-iOS */,
 			);
 			name = "TWOSOMEHEART-iOS";
 			packageProductDependencies = (
@@ -136,6 +280,11 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				059C45622CEE0B5A00FB00DC /* LaunchScreen.storyboard in Resources */,
+				059C45632CEE0B5A00FB00DC /* AppleSDGothicNeo-Bold.ttf in Resources */,
+				059C45642CEE0B5A00FB00DC /* AppleSDGothicNeo-Regular.ttf in Resources */,
+				059C45652CEE0B5A00FB00DC /* AppleSDGothicNeo-SemiBold.ttf in Resources */,
+				059C45662CEE0B5A00FB00DC /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -146,10 +295,37 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				059C45512CEE0B5A00FB00DC /* AppDelegate.swift in Sources */,
+				059C45522CEE0B5A00FB00DC /* SceneDelegate.swift in Sources */,
+				059C45532CEE0B5A00FB00DC /* String+.swift in Sources */,
+				059C45542CEE0B5A00FB00DC /* UILabel+.swift in Sources */,
+				059C45552CEE0B5A00FB00DC /* UIStackView+.swift in Sources */,
+				059C45562CEE0B5A00FB00DC /* UIView+.swift in Sources */,
+				059C45572CEE0B5A00FB00DC /* TSFont.swift in Sources */,
+				059C45582CEE0B5A00FB00DC /* CounterView.swift in Sources */,
+				059C45592CEE0B5A00FB00DC /* CustomSegmentControlView.swift in Sources */,
+				059C455A2CEE0B5A00FB00DC /* CounterType.swift in Sources */,
+				059C455B2CEE0B5A00FB00DC /* SegmentType.swift in Sources */,
+				059C455C2CEE0B5A00FB00DC /* ScreenUtils.swift in Sources */,
+				059C455D2CEE0B5A00FB00DC /* StringLiterals.swift in Sources */,
+				059C455E2CEE0B5A00FB00DC /* BaseNavViewController.swift in Sources */,
+				059C455F2CEE0B5A00FB00DC /* BaseViewController.swift in Sources */,
+				059C45602CEE0B5A00FB00DC /* ViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		059C45302CEE0B5A00FB00DC /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				059C452F2CEE0B5A00FB00DC /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		742A43A82CE88EAA00535185 /* Debug */ = {

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		059C45682CEE0E6600FB00DC /* ReusableIdentifier+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45672CEE0E6600FB00DC /* ReusableIdentifier+.swift */; };
 		059C45722CEE0F9B00FB00DC /* BaseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45712CEE0F9B00FB00DC /* BaseTableViewCell.swift */; };
 		059C45742CEE107700FB00DC /* MenuOptionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45732CEE107700FB00DC /* MenuOptionHeader.swift */; };
+		059C45762CEE10D800FB00DC /* MenuOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45752CEE10D800FB00DC /* MenuOption.swift */; };
 		742A43CA2CE8918600535185 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43C92CE8918600535185 /* SnapKit */; };
 		742A43CF2CE8919300535185 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CE2CE8919300535185 /* Then */; };
 /* End PBXBuildFile section */
@@ -61,6 +62,7 @@
 		059C45672CEE0E6600FB00DC /* ReusableIdentifier+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReusableIdentifier+.swift"; sourceTree = "<group>"; };
 		059C45712CEE0F9B00FB00DC /* BaseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewCell.swift; sourceTree = "<group>"; };
 		059C45732CEE107700FB00DC /* MenuOptionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionHeader.swift; sourceTree = "<group>"; };
+		059C45752CEE10D800FB00DC /* MenuOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOption.swift; sourceTree = "<group>"; };
 		742A43942CE88EA700535185 /* TWOSOMEHEART-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TWOSOMEHEART-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -258,6 +260,7 @@
 			isa = PBXGroup;
 			children = (
 				059C45732CEE107700FB00DC /* MenuOptionHeader.swift */,
+				059C45752CEE10D800FB00DC /* MenuOption.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -381,6 +384,7 @@
 				059C45582CEE0B5A00FB00DC /* CounterView.swift in Sources */,
 				059C45592CEE0B5A00FB00DC /* CustomSegmentControlView.swift in Sources */,
 				059C455A2CEE0B5A00FB00DC /* CounterType.swift in Sources */,
+				059C45762CEE10D800FB00DC /* MenuOption.swift in Sources */,
 				059C455B2CEE0B5A00FB00DC /* SegmentType.swift in Sources */,
 				059C455C2CEE0B5A00FB00DC /* ScreenUtils.swift in Sources */,
 				059C455D2CEE0B5A00FB00DC /* StringLiterals.swift in Sources */,

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		059C457F2CEE198300FB00DC /* SnapKit-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CB2CE8918600535185 /* SnapKit-Dynamic */; };
 		059C45812CEE199300FB00DC /* MenuOptionSyrupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45802CEE199300FB00DC /* MenuOptionSyrupCell.swift */; };
 		059C45832CEE19EA00FB00DC /* MenuOptionWhippedCreamCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45822CEE19EA00FB00DC /* MenuOptionWhippedCreamCell.swift */; };
+		059C45852CEE1A3700FB00DC /* MenuOptionDrizzleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45842CEE1A3700FB00DC /* MenuOptionDrizzleCell.swift */; };
 		742A43CA2CE8918600535185 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43C92CE8918600535185 /* SnapKit */; };
 		742A43CF2CE8919300535185 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CE2CE8919300535185 /* Then */; };
 /* End PBXBuildFile section */
@@ -74,6 +75,7 @@
 		059C457D2CEE18EF00FB00DC /* MenuOptionShotCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionShotCell.swift; sourceTree = "<group>"; };
 		059C45802CEE199300FB00DC /* MenuOptionSyrupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionSyrupCell.swift; sourceTree = "<group>"; };
 		059C45822CEE19EA00FB00DC /* MenuOptionWhippedCreamCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionWhippedCreamCell.swift; sourceTree = "<group>"; };
+		059C45842CEE1A3700FB00DC /* MenuOptionDrizzleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionDrizzleCell.swift; sourceTree = "<group>"; };
 		742A43942CE88EA700535185 /* TWOSOMEHEART-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TWOSOMEHEART-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -269,6 +271,7 @@
 				059C457D2CEE18EF00FB00DC /* MenuOptionShotCell.swift */,
 				059C45802CEE199300FB00DC /* MenuOptionSyrupCell.swift */,
 				059C45822CEE19EA00FB00DC /* MenuOptionWhippedCreamCell.swift */,
+				059C45842CEE1A3700FB00DC /* MenuOptionDrizzleCell.swift */,
 			);
 			path = TableViewCell;
 			sourceTree = "<group>";
@@ -412,6 +415,7 @@
 				059C455E2CEE0B5A00FB00DC /* BaseNavViewController.swift in Sources */,
 				059C455F2CEE0B5A00FB00DC /* BaseViewController.swift in Sources */,
 				059C45602CEE0B5A00FB00DC /* ViewController.swift in Sources */,
+				059C45852CEE1A3700FB00DC /* MenuOptionDrizzleCell.swift in Sources */,
 				059C457E2CEE18EF00FB00DC /* MenuOptionShotCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		059C45782CEE113D00FB00DC /* MenuOptionSectionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45772CEE113D00FB00DC /* MenuOptionSectionType.swift */; };
 		059C457A2CEE16A200FB00DC /* MenuOptionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45792CEE16A200FB00DC /* MenuOptionHeaderView.swift */; };
 		059C457E2CEE18EF00FB00DC /* MenuOptionShotCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C457D2CEE18EF00FB00DC /* MenuOptionShotCell.swift */; };
+		059C457F2CEE198300FB00DC /* SnapKit-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CB2CE8918600535185 /* SnapKit-Dynamic */; };
+		059C45812CEE199300FB00DC /* MenuOptionSyrupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45802CEE199300FB00DC /* MenuOptionSyrupCell.swift */; };
 		742A43CA2CE8918600535185 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43C92CE8918600535185 /* SnapKit */; };
 		742A43CF2CE8919300535185 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CE2CE8919300535185 /* Then */; };
 /* End PBXBuildFile section */
@@ -69,6 +71,7 @@
 		059C45772CEE113D00FB00DC /* MenuOptionSectionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionSectionType.swift; sourceTree = "<group>"; };
 		059C45792CEE16A200FB00DC /* MenuOptionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionHeaderView.swift; sourceTree = "<group>"; };
 		059C457D2CEE18EF00FB00DC /* MenuOptionShotCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionShotCell.swift; sourceTree = "<group>"; };
+		059C45802CEE199300FB00DC /* MenuOptionSyrupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionSyrupCell.swift; sourceTree = "<group>"; };
 		742A43942CE88EA700535185 /* TWOSOMEHEART-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TWOSOMEHEART-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -77,6 +80,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				059C457F2CEE198300FB00DC /* SnapKit-Dynamic in Frameworks */,
 				742A43CA2CE8918600535185 /* SnapKit in Frameworks */,
 				742A43CF2CE8919300535185 /* Then in Frameworks */,
 			);
@@ -261,6 +265,7 @@
 			isa = PBXGroup;
 			children = (
 				059C457D2CEE18EF00FB00DC /* MenuOptionShotCell.swift */,
+				059C45802CEE199300FB00DC /* MenuOptionSyrupCell.swift */,
 			);
 			path = TableViewCell;
 			sourceTree = "<group>";
@@ -393,6 +398,7 @@
 				059C45742CEE107700FB00DC /* MenuOptionHeader.swift in Sources */,
 				059C45582CEE0B5A00FB00DC /* CounterView.swift in Sources */,
 				059C45592CEE0B5A00FB00DC /* CustomSegmentControlView.swift in Sources */,
+				059C45812CEE199300FB00DC /* MenuOptionSyrupCell.swift in Sources */,
 				059C455A2CEE0B5A00FB00DC /* CounterType.swift in Sources */,
 				059C45762CEE10D800FB00DC /* MenuOption.swift in Sources */,
 				059C457A2CEE16A200FB00DC /* MenuOptionHeaderView.swift in Sources */,

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		059C457E2CEE18EF00FB00DC /* MenuOptionShotCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C457D2CEE18EF00FB00DC /* MenuOptionShotCell.swift */; };
 		059C457F2CEE198300FB00DC /* SnapKit-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CB2CE8918600535185 /* SnapKit-Dynamic */; };
 		059C45812CEE199300FB00DC /* MenuOptionSyrupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45802CEE199300FB00DC /* MenuOptionSyrupCell.swift */; };
+		059C45832CEE19EA00FB00DC /* MenuOptionWhippedCreamCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45822CEE19EA00FB00DC /* MenuOptionWhippedCreamCell.swift */; };
 		742A43CA2CE8918600535185 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43C92CE8918600535185 /* SnapKit */; };
 		742A43CF2CE8919300535185 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CE2CE8919300535185 /* Then */; };
 /* End PBXBuildFile section */
@@ -72,6 +73,7 @@
 		059C45792CEE16A200FB00DC /* MenuOptionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionHeaderView.swift; sourceTree = "<group>"; };
 		059C457D2CEE18EF00FB00DC /* MenuOptionShotCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionShotCell.swift; sourceTree = "<group>"; };
 		059C45802CEE199300FB00DC /* MenuOptionSyrupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionSyrupCell.swift; sourceTree = "<group>"; };
+		059C45822CEE19EA00FB00DC /* MenuOptionWhippedCreamCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionWhippedCreamCell.swift; sourceTree = "<group>"; };
 		742A43942CE88EA700535185 /* TWOSOMEHEART-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TWOSOMEHEART-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -266,6 +268,7 @@
 			children = (
 				059C457D2CEE18EF00FB00DC /* MenuOptionShotCell.swift */,
 				059C45802CEE199300FB00DC /* MenuOptionSyrupCell.swift */,
+				059C45822CEE19EA00FB00DC /* MenuOptionWhippedCreamCell.swift */,
 			);
 			path = TableViewCell;
 			sourceTree = "<group>";
@@ -393,6 +396,7 @@
 				059C45722CEE0F9B00FB00DC /* BaseTableViewCell.swift in Sources */,
 				059C45542CEE0B5A00FB00DC /* UILabel+.swift in Sources */,
 				059C45552CEE0B5A00FB00DC /* UIStackView+.swift in Sources */,
+				059C45832CEE19EA00FB00DC /* MenuOptionWhippedCreamCell.swift in Sources */,
 				059C45562CEE0B5A00FB00DC /* UIView+.swift in Sources */,
 				059C45572CEE0B5A00FB00DC /* TSFont.swift in Sources */,
 				059C45742CEE107700FB00DC /* MenuOptionHeader.swift in Sources */,

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		059C45812CEE199300FB00DC /* MenuOptionSyrupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45802CEE199300FB00DC /* MenuOptionSyrupCell.swift */; };
 		059C45832CEE19EA00FB00DC /* MenuOptionWhippedCreamCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45822CEE19EA00FB00DC /* MenuOptionWhippedCreamCell.swift */; };
 		059C45852CEE1A3700FB00DC /* MenuOptionDrizzleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45842CEE1A3700FB00DC /* MenuOptionDrizzleCell.swift */; };
+		059C45872CEE1A9F00FB00DC /* MenuOptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45862CEE1A9F00FB00DC /* MenuOptionViewController.swift */; };
 		059C45892CEE1BBB00FB00DC /* CounterViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45882CEE1BBB00FB00DC /* CounterViewDelegate.swift */; };
 		742A43CA2CE8918600535185 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43C92CE8918600535185 /* SnapKit */; };
 		742A43CF2CE8919300535185 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CE2CE8919300535185 /* Then */; };
@@ -76,6 +77,7 @@
 		059C45802CEE199300FB00DC /* MenuOptionSyrupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionSyrupCell.swift; sourceTree = "<group>"; };
 		059C45822CEE19EA00FB00DC /* MenuOptionWhippedCreamCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionWhippedCreamCell.swift; sourceTree = "<group>"; };
 		059C45842CEE1A3700FB00DC /* MenuOptionDrizzleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionDrizzleCell.swift; sourceTree = "<group>"; };
+		059C45862CEE1A9F00FB00DC /* MenuOptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionViewController.swift; sourceTree = "<group>"; };
 		059C45882CEE1BBB00FB00DC /* CounterViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterViewDelegate.swift; sourceTree = "<group>"; };
 		742A43942CE88EA700535185 /* TWOSOMEHEART-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TWOSOMEHEART-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -235,6 +237,7 @@
 		059C456A2CEE0F4A00FB00DC /* Controller */ = {
 			isa = PBXGroup;
 			children = (
+				059C45862CEE1A9F00FB00DC /* MenuOptionViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -409,6 +412,7 @@
 				059C45592CEE0B5A00FB00DC /* CustomSegmentControlView.swift in Sources */,
 				059C45812CEE199300FB00DC /* MenuOptionSyrupCell.swift in Sources */,
 				059C455A2CEE0B5A00FB00DC /* CounterType.swift in Sources */,
+				059C45872CEE1A9F00FB00DC /* MenuOptionViewController.swift in Sources */,
 				059C45762CEE10D800FB00DC /* MenuOption.swift in Sources */,
 				059C457A2CEE16A200FB00DC /* MenuOptionHeaderView.swift in Sources */,
 				059C455B2CEE0B5A00FB00DC /* SegmentType.swift in Sources */,

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		059C45742CEE107700FB00DC /* MenuOptionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45732CEE107700FB00DC /* MenuOptionHeader.swift */; };
 		059C45762CEE10D800FB00DC /* MenuOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45752CEE10D800FB00DC /* MenuOption.swift */; };
 		059C45782CEE113D00FB00DC /* MenuOptionSectionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45772CEE113D00FB00DC /* MenuOptionSectionType.swift */; };
+		059C457A2CEE16A200FB00DC /* MenuOptionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059C45792CEE16A200FB00DC /* MenuOptionHeaderView.swift */; };
 		742A43CA2CE8918600535185 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43C92CE8918600535185 /* SnapKit */; };
 		742A43CF2CE8919300535185 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 742A43CE2CE8919300535185 /* Then */; };
 /* End PBXBuildFile section */
@@ -65,6 +66,7 @@
 		059C45732CEE107700FB00DC /* MenuOptionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionHeader.swift; sourceTree = "<group>"; };
 		059C45752CEE10D800FB00DC /* MenuOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOption.swift; sourceTree = "<group>"; };
 		059C45772CEE113D00FB00DC /* MenuOptionSectionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionSectionType.swift; sourceTree = "<group>"; };
+		059C45792CEE16A200FB00DC /* MenuOptionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuOptionHeaderView.swift; sourceTree = "<group>"; };
 		742A43942CE88EA700535185 /* TWOSOMEHEART-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TWOSOMEHEART-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -248,6 +250,7 @@
 		059C456D2CEE0F6000FB00DC /* HeaderView */ = {
 			isa = PBXGroup;
 			children = (
+				059C45792CEE16A200FB00DC /* MenuOptionHeaderView.swift */,
 			);
 			path = HeaderView;
 			sourceTree = "<group>";
@@ -389,6 +392,7 @@
 				059C45592CEE0B5A00FB00DC /* CustomSegmentControlView.swift in Sources */,
 				059C455A2CEE0B5A00FB00DC /* CounterType.swift in Sources */,
 				059C45762CEE10D800FB00DC /* MenuOption.swift in Sources */,
+				059C457A2CEE16A200FB00DC /* MenuOptionHeaderView.swift in Sources */,
 				059C455B2CEE0B5A00FB00DC /* SegmentType.swift in Sources */,
 				059C455C2CEE0B5A00FB00DC /* ScreenUtils.swift in Sources */,
 				059C455D2CEE0B5A00FB00DC /* StringLiterals.swift in Sources */,

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Extensions/ReusableIdentifier+.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Extensions/ReusableIdentifier+.swift
@@ -1,0 +1,23 @@
+//
+//  ReusableIdentifier+.swift
+//  TWOSOMEHEART-iOS
+//
+//  Created by RAFA on 11/20/24.
+//
+
+import UIKit
+
+protocol ReusableIdentifier: AnyObject {}
+
+extension ReusableIdentifier where Self: UIView {
+
+    static var identifier: String {
+        return String(describing: self)
+    }
+}
+
+extension UICollectionReusableView: ReusableIdentifier {}
+
+extension UITableViewCell: ReusableIdentifier {}
+
+extension UITableViewHeaderFooterView: ReusableIdentifier {}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Extensions/UILabel+.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Extensions/UILabel+.swift
@@ -20,5 +20,31 @@ extension UILabel {
         self.textColor = textColor
         self.font = font
     }
-    
+
+    func setAttributedText(
+        fullText: String,
+        styles: [(text: String, font: UIFont, color: UIColor)]
+    ) {
+        let attributedString = NSMutableAttributedString(string: fullText)
+
+        styles.forEach { style in
+            if let range = fullText.range(of: style.text) {
+                let nsRange = NSRange(range, in: fullText)
+                attributedString.addAttribute(
+                    .font,
+                    value: style.font,
+                    range: nsRange
+                )
+
+                attributedString.addAttribute(
+                    .foregroundColor,
+                    value: style.color,
+                    range: nsRange
+                )
+            }
+        }
+
+        self.attributedText = attributedString
+    }
+
 }

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Extensions/UIStackView+.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Extensions/UIStackView+.swift
@@ -16,7 +16,7 @@ extension UIStackView {
     func setStackView(axis: NSLayoutConstraint.Axis = .horizontal,
                       distribution: UIStackView.Distribution = .fillEqually,
                       alignment: UIStackView.Alignment = .fill,
-                      spacng: Int?) {
+                      spacing: CGFloat = 0) {
         self.axis = axis
         self.distribution = distribution
         self.alignment = alignment

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/UIComponents/CounterView.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/UIComponents/CounterView.swift
@@ -33,7 +33,7 @@ class CounterView : UIView {
         
         super.init(frame: .zero)
         
-        setHierachy()
+        setHierarchy()
         setLayout()
         setStyle()
     }
@@ -42,7 +42,7 @@ class CounterView : UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func setHierachy() {
+    func setHierarchy() {
         self.addSubviews(stackView)
         
         stackView.addSubviews(minusButton,

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/UIComponents/CounterView.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/UIComponents/CounterView.swift
@@ -23,11 +23,14 @@ class CounterView : UIView {
     private var numberCount: Int = 0 {
         didSet {
             updateUI()
+            onValueChanged?(numberCount)
         }
     }
     
     private var counterType: CounterType
-    
+
+    var onValueChanged: ((Int) -> Void)?
+
     init(counterType: CounterType) {
         self.counterType = counterType
         
@@ -129,5 +132,10 @@ extension CounterView {
         countLabel.text = "\(numberCount)"
         minusButton.isEnabled = (numberCount != 0)
     }
-    
+
+    func resetCounter() {
+        let change = -numberCount
+        updateNumberCount(change)
+    }
+
 }

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/UIComponents/CounterView.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/UIComponents/CounterView.swift
@@ -73,7 +73,7 @@ class CounterView : UIView {
     
     func setStyle() {
         stackView.do {
-            $0.setStackView(spacng: -1)
+            $0.setStackView(spacing: -1)
         }
         
         for views in stackView.arrangedSubviews {

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/UIComponents/CustomSegmentControlView.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/UIComponents/CustomSegmentControlView.swift
@@ -52,7 +52,7 @@ class CustomSegmentControlView: UIView {
     
     private func setStyle() {
         stackView.do {
-            $0.setStackView(spacng: -1)
+            $0.setStackView(spacing: -1)
         }
         
         buttons.enumerated().forEach { index, button in

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Utils/Aliases.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Utils/Aliases.swift
@@ -1,0 +1,10 @@
+//
+//  Aliases.swift
+//  TWOSOMEHEART-iOS
+//
+//  Created by RAFA on 11/21/24.
+//
+
+import Foundation
+
+typealias SLMenuOption = StringLiterals.MenuOptionType

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Utils/StringLiterals.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Utils/StringLiterals.swift
@@ -38,4 +38,27 @@ enum StringLiterals {
         static let icecream = "아이스크림/빙수"
         
     }
+
+    enum MenuOptionType {
+
+        static let density = "농도"
+
+        static let addShot = "샷 추가"
+
+        static let vanillaSyrup = "바닐라시럽"
+
+        static let hazelnutSyrup = "헤이즐넛시럽"
+
+        static let caramelSyrup = "카라멜시럽"
+
+        static let whippedCream = "휘핑크림"
+
+        static let caramelDrizzle = "카라멜드리즐"
+
+        static let chocolateDrizzle = "초콜릿드리즐"
+
+        static let pricePerPlusOne = "(+1에 500원)"
+
+    }
+
 }

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/Base/BaseTableViewCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/Base/BaseTableViewCell.swift
@@ -1,0 +1,39 @@
+//
+//  BaseTableViewCell.swift
+//  TWOSOMEHEART-iOS
+//
+//  Created by RAFA on 11/20/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class BaseTableViewCell: UITableViewCell {
+
+    // MARK: - Initializer
+
+    override init(
+        style: UITableViewCell.CellStyle,
+        reuseIdentifier: String?
+    ) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        setStyle()
+        setHierarchy()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - UI
+
+    func setStyle() {}
+
+    func setHierarchy() {}
+
+    func setLayout() {}
+}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/Base/BaseView.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/Base/BaseView.swift
@@ -1,0 +1,36 @@
+//
+//  BaseView.swift
+//  TWOSOMEHEART-iOS
+//
+//  Created by RAFA on 11/21/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class BaseView: UIView {
+
+    // MARK: - Initializer
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setStyle()
+        setHierarchy()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - UI
+
+    func setStyle() {}
+
+    func setHierarchy() {}
+
+    func setLayout() {}
+}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/Base/BaseViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/Base/BaseViewController.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 
+import SnapKit
+import Then
+
 class BaseViewController: UIViewController {
     
     // MARK: - Life Cycle

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Controller/MenuOptionViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Controller/MenuOptionViewController.swift
@@ -257,6 +257,7 @@ extension MenuOptionViewController: UITableViewDelegate {
 
         let data = headerItems[section]
         headerView.configure(data)
+        headerView.configureGesture(delegate: self, section: section)
 
         return headerView
     }
@@ -284,6 +285,21 @@ extension MenuOptionViewController: UITableViewDelegate {
         _ tableView: UITableView,
         heightForHeaderInSection section: Int) -> CGFloat {
         return 86
+    }
+}
+
+// MARK: - HeaderViewDelegate
+
+extension MenuOptionViewController: MenuOptionHeaderViewDelegate {
+
+    func didTapHeader(section: Int) {
+        headerItems.enumerated().forEach { index, _ in
+            headerItems[index].isExpanded = (index == section) ?
+            !headerItems[index].isExpanded : false
+        }
+
+        expandedSection = headerItems[section].isExpanded ? section : nil
+        tableView.reloadData()
     }
 }
 

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Controller/MenuOptionViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Controller/MenuOptionViewController.swift
@@ -288,7 +288,7 @@ extension MenuOptionViewController: UITableViewDelegate {
     }
 }
 
-// MARK: - HeaderViewDelegate
+// MARK: - MenuOptionHeaderViewDelegate
 
 extension MenuOptionViewController: MenuOptionHeaderViewDelegate {
 

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Controller/MenuOptionViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Controller/MenuOptionViewController.swift
@@ -1,0 +1,340 @@
+//
+//  MenuOptionViewController.swift
+//  TWOSOMEHEART-iOS
+//
+//  Created by RAFA on 11/20/24.
+//
+
+import UIKit
+
+final class MenuOptionViewController: BaseViewController {
+
+    // MARK: - UI Properties
+
+    private let tableView = UITableView()
+    private let bottomView = UIView()
+    private let separatorView = UIView()
+    private let totalPriceLabel = UILabel()
+    private let currencyUnitLabel = UILabel()
+    private let totalPriceStackView = UIStackView()
+    private let resetButton = UIButton(type: .system)
+    private let selectButton = UIButton(type: .system)
+
+    // MARK: - Properties
+
+    private let sections: [MenuOptionSectionType] = MenuOptionSectionType.allCases
+    private var headerItems: [MenuOptionHeader] = []
+    private let menuOptions = MenuOption.menuOptions
+    private var expandedSection: Int?
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setDelegates()
+        registerCells()
+        initializeHeaderItems()
+    }
+
+    // MARK: - Helpers
+
+    private func initializeHeaderItems() {
+        headerItems = sections.map { sectionType in
+            let itemCount: Int
+            switch sectionType {
+            case .shot: itemCount = 1
+            case .syrup: itemCount = 3
+            case .whippedCream: itemCount = 1
+            case .drizzle: itemCount = 2
+            }
+
+            return MenuOptionHeader(
+                title: sectionType.rawValue,
+                arrowImage: UIImage(resource: .optionArrowDown),
+                price: 0,
+                itemPrices: Array(repeating: 0, count: itemCount),
+                isExpanded: false,
+                addedOptions: nil
+            )
+        }
+    }
+
+    private func setDelegates() {
+        tableView.delegate = self
+        tableView.dataSource = self
+    }
+
+    private func registerCells() {
+        tableView.register(
+            MenuOptionHeaderView.self,
+            forHeaderFooterViewReuseIdentifier: MenuOptionHeaderView.identifier
+        )
+
+        tableView.register(
+            MenuOptionShotCell.self,
+            forCellReuseIdentifier: MenuOptionShotCell.identifier
+        )
+
+        tableView.register(
+            MenuOptionSyrupCell.self,
+            forCellReuseIdentifier: MenuOptionSyrupCell.identifier
+        )
+
+        tableView.register(
+            MenuOptionWhippedCreamCell.self,
+            forCellReuseIdentifier: MenuOptionWhippedCreamCell.identifier
+        )
+
+        tableView.register(
+            MenuOptionDrizzleCell.self,
+            forCellReuseIdentifier: MenuOptionDrizzleCell.identifier
+        )
+    }
+
+    // MARK: - UI
+
+    override func setStyle() {
+        view.backgroundColor = .tsWhite
+        bottomView.backgroundColor = .tsWhite
+        separatorView.backgroundColor = .tsBlack
+
+        tableView.do {
+            $0.separatorStyle = .none
+            $0.sectionHeaderTopPadding = 0
+            $0.estimatedRowHeight = 161
+            $0.sectionHeaderHeight = 86
+            $0.estimatedSectionHeaderHeight = 86
+            $0.rowHeight = UITableView.automaticDimension
+        }
+
+        totalPriceLabel.do {
+            $0.setLabel(
+                text: "0",
+                alignment: .left,
+                textColor: .tsBlack,
+                font: TSFont.h1b
+            )
+        }
+
+        currencyUnitLabel.do {
+            $0.setLabel(
+                text: " 원",
+                alignment: .left,
+                textColor: .tsBlack,
+                font: TSFont.h2r
+            )
+        }
+
+        totalPriceStackView.do {
+            $0.addArrangedSubviews([
+                totalPriceLabel,
+                currencyUnitLabel
+            ])
+
+            $0.setStackView(spacing: 5)
+        }
+
+        resetButton.do {
+            var config = UIButton.Configuration.plain()
+            config.image = .optionReset
+            config.imagePlacement = .trailing
+            config.imagePadding = 3
+            config.contentInsets = .zero
+            config.baseForegroundColor = .red40
+            $0.configuration = config
+            $0.setAttributedTitle(
+                NSAttributedString(
+                    string: "초기화",
+                    attributes: [.font: TSFont.c1r]
+                ),
+                for: .normal
+            )
+        }
+
+        selectButton.do {
+            $0.backgroundColor = .tsBlack
+            $0.setTitle("선택하기", for: .normal)
+            $0.setTitleColor(.tsWhite, for: .normal)
+            $0.titleLabel?.font = TSFont.btn1s
+        }
+    }
+
+    override func setHierarchy() {
+        bottomView.addSubviews(
+            separatorView,
+            totalPriceStackView,
+            resetButton,
+            selectButton
+        )
+
+        view.addSubviews(tableView, bottomView)
+    }
+
+    override func setLayout() {
+        tableView.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview()
+        }
+
+        bottomView.snp.makeConstraints {
+            $0.top.equalTo(tableView.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
+            $0.height.greaterThanOrEqualTo(135)
+        }
+
+        separatorView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(1)
+        }
+
+        totalPriceStackView.snp.makeConstraints {
+            $0.top.equalTo(separatorView.snp.bottom).offset(17)
+            $0.leading.equalTo(separatorView)
+        }
+
+        resetButton.snp.makeConstraints {
+            $0.centerY.equalTo(totalPriceStackView)
+            $0.leading.greaterThanOrEqualTo(totalPriceStackView.snp.trailing).offset(10)
+            $0.trailing.equalTo(separatorView.snp.trailing)
+            $0.height.equalTo(44)
+        }
+
+        selectButton.snp.makeConstraints {
+            $0.top.equalTo(resetButton.snp.bottom).offset(23)
+            $0.horizontalEdges.equalToSuperview().inset(15.95)
+            $0.bottom.equalTo(bottomView.snp.bottom).inset(15.87)
+            $0.height.equalTo(46)
+        }
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension MenuOptionViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return headerItems.count
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        numberOfRowsInSection section: Int
+    ) -> Int {
+        return expandedSection == section ? 1 : 0
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        cellForRowAt indexPath: IndexPath
+    ) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: identifier(for: indexPath.section),
+            for: indexPath
+        )
+
+        configureCell(cell, for: indexPath.section)
+        addSeparator(to: cell)
+
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension MenuOptionViewController: UITableViewDelegate {
+
+    func tableView(
+        _ tableView: UITableView,
+        viewForHeaderInSection section: Int
+    ) -> UIView? {
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(
+            withIdentifier: MenuOptionHeaderView.identifier
+        ) as? MenuOptionHeaderView else {
+            return nil
+        }
+
+        let data = headerItems[section]
+        headerView.configure(data)
+
+        return headerView
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        viewForFooterInSection section: Int
+    ) -> UIView? {
+        guard section != sections.count - 1 else { return nil }
+
+        let footerView = UIView()
+        footerView.backgroundColor = .gray20
+
+        return footerView
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        heightForFooterInSection section: Int
+    ) -> CGFloat {
+        return section == sections.count - 1 ? 0 : 1
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        heightForHeaderInSection section: Int) -> CGFloat {
+        return 86
+    }
+}
+
+// MARK: - Helper Methods for TableView Configuration
+
+private extension MenuOptionViewController {
+
+    func addSeparator(to cell: UITableViewCell) {
+        let separator = UIView()
+        separator.backgroundColor = .gray20
+
+        cell.contentView.addSubview(separator)
+
+        separator.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+    }
+
+    func identifier(for section: Int) -> String {
+        switch section {
+        case 0: return MenuOptionShotCell.identifier
+        case 1: return MenuOptionSyrupCell.identifier
+        case 2: return MenuOptionWhippedCreamCell.identifier
+        case 3: return MenuOptionDrizzleCell.identifier
+        default: return ""
+        }
+    }
+
+    func configureCommonCellStyle(for cell: UITableViewCell) {
+        cell.backgroundColor = .gray10
+        cell.selectionStyle = .none
+    }
+
+    func configureCell(_ cell: UITableViewCell, for section: Int) {
+        switch cell {
+        case let cell as MenuOptionShotCell:
+            configureCommonCellStyle(for: cell)
+
+        case let cell as MenuOptionSyrupCell:
+            configureCommonCellStyle(for: cell)
+
+        case let cell as MenuOptionWhippedCreamCell:
+            configureCommonCellStyle(for: cell)
+
+        case let cell as MenuOptionDrizzleCell:
+            configureCommonCellStyle(for: cell)
+
+        default:
+            break
+        }
+    }
+}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Controller/MenuOptionViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Controller/MenuOptionViewController.swift
@@ -137,7 +137,7 @@ final class MenuOptionViewController: BaseViewController {
 
         currencyUnitLabel.do {
             $0.setLabel(
-                text: " 원",
+                text: "원",
                 alignment: .left,
                 textColor: .tsBlack,
                 font: TSFont.h2r

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Controller/MenuOptionViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Controller/MenuOptionViewController.swift
@@ -301,7 +301,8 @@ extension MenuOptionViewController: UITableViewDelegate {
 
     func tableView(
         _ tableView: UITableView,
-        heightForHeaderInSection section: Int) -> CGFloat {
+        heightForHeaderInSection section: Int
+    ) -> CGFloat {
         return 86
     }
 }

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Model/MenuOption.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Model/MenuOption.swift
@@ -1,0 +1,26 @@
+//
+//  MenuOption.swift
+//  TWOSOMEHEART-iOS
+//
+//  Created by RAFA on 11/20/24.
+//
+
+import Foundation
+
+struct MenuOption {
+
+    let section: Int
+    let options: [String]
+}
+
+// MARK: - Mock Data
+
+extension MenuOption {
+
+    static let menuOptions: [MenuOption] = [
+        MenuOption(section: 0, options: ["샷추가"]),
+        MenuOption(section: 1, options: ["바닐라시럽", "헤이즐넛시럽", "카라멜시럽"]),
+        MenuOption(section: 2, options: ["휘핑크림"]),
+        MenuOption(section: 3, options: ["카라멜드리즐", "초콜릿드리즐"])
+    ]
+}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Model/MenuOptionHeader.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Model/MenuOptionHeader.swift
@@ -1,0 +1,18 @@
+//
+//  MenuOptionHeader.swift
+//  TWOSOMEHEART-iOS
+//
+//  Created by RAFA on 11/20/24.
+//
+
+import UIKit
+
+struct MenuOptionHeader {
+
+    let title: String
+    let arrowImage: UIImage
+    var price: Int = 0
+    var itemPrices: [Int] = []
+    var isExpanded: Bool
+    var addedOptions: String?
+}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Protocol/CounterViewDelegate.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/Protocol/CounterViewDelegate.swift
@@ -1,0 +1,16 @@
+//
+//  CounterViewDelegate.swift
+//  TWOSOMEHEART-iOS
+//
+//  Created by RAFA on 11/20/24.
+//
+
+import Foundation
+
+protocol PriceUpdateDelegate: AnyObject {
+    func priceDidChange(section: Int, itemIndex: Int, count: Int)
+}
+
+protocol ResetCounterDelegate: AnyObject {
+    func resetCounters()
+}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/HeaderView/MenuOptionHeaderView.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/HeaderView/MenuOptionHeaderView.swift
@@ -1,0 +1,117 @@
+//
+//  MenuOptionHeaderView.swift
+//  TWOSOMEHEART-iOS
+//
+//  Created by RAFA on 11/20/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class MenuOptionHeaderView: UITableViewHeaderFooterView {
+
+    // MARK: - UI Properties
+
+    private let titleLabel = UILabel()
+    private let priceLabel = UILabel()
+    private let currencyUnitLabel = UILabel()
+    private let priceStackView = UIStackView()
+    private let arrowImageView = UIImageView()
+    private let addedOptionLabel = UILabel()
+
+    // MARK: - Initializers
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+
+        setStyle()
+        setHierarchy()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - UI
+
+    private func setStyle() {
+        titleLabel.do {
+            $0.setLabel(
+                textColor: .tsBlack,
+                font: TSFont.h3r
+            )
+        }
+
+        priceLabel.do {
+            $0.setLabel(
+                numberOfLines: 1,
+                textColor: .gray80,
+                font: TSFont.b1b
+            )
+        }
+
+        currencyUnitLabel.do {
+            $0.setLabel(
+                text: "원",
+                numberOfLines: 1,
+                textColor: .gray80,
+                font: TSFont.b1b
+            )
+        }
+
+        priceStackView.do {
+            $0.addArrangedSubviews([priceLabel, currencyUnitLabel])
+            $0.setStackView(distribution: .fillProportionally)
+        }
+
+        arrowImageView.do {
+            $0.image = UIImage(resource: .optionArrowDown)
+            $0.tintColor = .tsBlack
+        }
+
+        addedOptionLabel.do {
+            $0.setLabel(
+                alignment: .left,
+                textColor: .gray70,
+                font: TSFont.c2r
+            )
+        }
+    }
+
+    private func setHierarchy() {
+        contentView.addSubviews(
+            titleLabel,
+            priceStackView,
+            arrowImageView,
+            addedOptionLabel
+        )
+    }
+
+    private func setLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(6)
+            $0.leading.equalTo(16)
+        }
+
+        priceStackView.snp.makeConstraints {
+            $0.centerY.equalTo(titleLabel)
+            $0.trailing.equalTo(arrowImageView.snp.leading).offset(-10)
+        }
+
+        arrowImageView.snp.makeConstraints {
+            $0.centerY.equalTo(priceStackView)
+            $0.trailing.equalTo(-16)
+        }
+
+        addedOptionLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(titleLabel.snp.bottom).offset(16)
+            $0.leading.equalTo(titleLabel)
+            $0.bottom.equalTo(-12)
+            $0.height.equalTo(18)
+        }
+    }
+}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/HeaderView/MenuOptionHeaderView.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/HeaderView/MenuOptionHeaderView.swift
@@ -35,6 +35,16 @@ final class MenuOptionHeaderView: UITableViewHeaderFooterView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - Helpers
+
+    func configure(_ item: MenuOptionHeader) {
+        titleLabel.text = item.title
+        updateTitleFont(isExpanded: item.isExpanded)
+        updateArrowImage(isExpanded: item.isExpanded)
+        updatePrice(price: item.price)
+        addedOptionLabel.text = item.addedOptions
+    }
+
     // MARK: - UI
 
     private func setStyle() {
@@ -112,6 +122,29 @@ final class MenuOptionHeaderView: UITableViewHeaderFooterView {
             $0.leading.equalTo(titleLabel)
             $0.bottom.equalTo(-12)
             $0.height.equalTo(18)
+        }
+    }
+}
+
+// MARK: - Update Methods
+
+private extension MenuOptionHeaderView {
+
+    func updateTitleFont(isExpanded: Bool) {
+        titleLabel.font = isExpanded ? TSFont.h3b : TSFont.h3r
+    }
+
+    func updateArrowImage(isExpanded: Bool) {
+        arrowImageView.image = UIImage(
+            resource: isExpanded ? .optionArrowUp : .optionArrowDown
+        )
+    }
+
+    func updatePrice(price: Int) {
+        if price > 0 {
+            priceLabel.text = "+ \(price)"
+        } else {
+            priceLabel.text = "\(price)"
         }
     }
 }

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/HeaderView/MenuOptionHeaderView.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/HeaderView/MenuOptionHeaderView.swift
@@ -25,6 +25,11 @@ final class MenuOptionHeaderView: UITableViewHeaderFooterView {
     private let arrowImageView = UIImageView()
     private let addedOptionLabel = UILabel()
 
+    // MARK: - Properties
+
+    weak var delegate: MenuOptionHeaderViewDelegate?
+    private var section: Int?
+
     // MARK: - Initializers
 
     override init(reuseIdentifier: String?) {
@@ -39,6 +44,13 @@ final class MenuOptionHeaderView: UITableViewHeaderFooterView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - Actions
+
+    @objc private func headerTapped() {
+        guard let section = section else { return }
+        delegate?.didTapHeader(section: section)
+    }
+
     // MARK: - Helpers
 
     func configure(_ item: MenuOptionHeader) {
@@ -47,6 +59,18 @@ final class MenuOptionHeaderView: UITableViewHeaderFooterView {
         updateArrowImage(isExpanded: item.isExpanded)
         updatePrice(price: item.price)
         addedOptionLabel.text = item.addedOptions
+    }
+
+    func configureGesture(delegate: MenuOptionHeaderViewDelegate?, section: Int) {
+        let tapGesture = UITapGestureRecognizer(
+            target: self,
+            action: #selector(headerTapped)
+        )
+
+        contentView.addGestureRecognizer(tapGesture)
+
+        self.section = section
+        self.delegate = delegate
     }
 
     // MARK: - UI

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/HeaderView/MenuOptionHeaderView.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/HeaderView/MenuOptionHeaderView.swift
@@ -10,6 +10,10 @@ import UIKit
 import SnapKit
 import Then
 
+protocol MenuOptionHeaderViewDelegate: AnyObject {
+    func didTapHeader(section: Int)
+}
+
 final class MenuOptionHeaderView: UITableViewHeaderFooterView {
 
     // MARK: - UI Properties

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/HeaderView/MenuOptionHeaderView.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/HeaderView/MenuOptionHeaderView.swift
@@ -96,7 +96,7 @@ final class MenuOptionHeaderView: UITableViewHeaderFooterView {
                 text: "원",
                 numberOfLines: 1,
                 textColor: .gray80,
-                font: TSFont.b1b
+                font: TSFont.c1r
             )
         }
 

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionDrizzleCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionDrizzleCell.swift
@@ -96,3 +96,13 @@ final class MenuOptionDrizzleCell: BaseTableViewCell {
         }
     }
 }
+
+// MARK: - ResetCounterDelegate
+
+extension MenuOptionDrizzleCell: ResetCounterDelegate {
+
+    func resetCounters() {
+        caramelCounterView.resetCounter()
+        chocolateCounterView.resetCounter()
+    }
+}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionDrizzleCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionDrizzleCell.swift
@@ -17,15 +17,44 @@ final class MenuOptionDrizzleCell: BaseTableViewCell {
     private let chocolateLabel = UILabel()
     let chocolateCounterView = CounterView(counterType: .option)
 
+    // MARK: - Properties
+
+    weak var priceDelegate: PriceUpdateDelegate?
+
     // MARK: - Initializer
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
+        updatePriceForCounterChange()
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Helpers
+
+    private func updatePriceForCounterChange() {
+        caramelCounterView.onValueChanged = { [weak self] count in
+            guard let self = self else { return }
+
+            self.priceDelegate?.priceDidChange(
+                section: 3,
+                itemIndex: 0,
+                count: count
+            )
+        }
+
+        chocolateCounterView.onValueChanged = { [weak self] count in
+            guard let self = self else { return }
+
+            self.priceDelegate?.priceDidChange(
+                section: 3,
+                itemIndex: 1,
+                count: count
+            )
+        }
     }
 
     // MARK: - UI

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionDrizzleCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionDrizzleCell.swift
@@ -91,8 +91,10 @@ final class MenuOptionDrizzleCell: BaseTableViewCell {
 
     override func setHierarchy() {
         contentView.addSubviews(
-            caramelLabel, caramelCounterView,
-            chocolateLabel, chocolateCounterView
+            caramelLabel,
+            caramelCounterView,
+            chocolateLabel,
+            chocolateCounterView
         )
     }
 

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionDrizzleCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionDrizzleCell.swift
@@ -1,0 +1,98 @@
+//
+//  MenuOptionDrizzleCell.swift
+//  TWOSOMEHEART-iOS
+//
+//  Created by RAFA on 11/20/24.
+//
+
+import UIKit
+
+final class MenuOptionDrizzleCell: BaseTableViewCell {
+
+    // MARK: - UI Properties
+
+    private let caramelLabel = UILabel()
+    let caramelCounterView = CounterView(counterType: .option)
+
+    private let chocolateLabel = UILabel()
+    let chocolateCounterView = CounterView(counterType: .option)
+
+    // MARK: - Initializer
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - UI
+
+    override func setStyle() {
+        caramelLabel.do {
+            $0.setAttributedText(
+                fullText: "카라멜드리즐 (+1에 500원)",
+                styles: [
+                    (text: "카라멜드리즐", font: TSFont.b2s, color: .gray90),
+                    (text: "(+1에 500원)", font: TSFont.c2b, color: .gray60)
+                ]
+            )
+
+            $0.textAlignment = .left
+        }
+
+        chocolateLabel.do {
+            $0.setAttributedText(
+                fullText: "초콜릿드리즐 (+1에 500원)",
+                styles: [
+                    (text: "초콜릿드리즐", font: TSFont.b2s, color: .gray90),
+                    (text: "(+1에 500원)", font: TSFont.c2b, color: .gray60)
+                ]
+            )
+
+            $0.textAlignment = .left
+        }
+
+        [caramelCounterView, chocolateCounterView].forEach {
+            $0.backgroundColor = .tsWhite
+        }
+    }
+
+    override func setHierarchy() {
+        contentView.addSubviews(
+            caramelLabel, caramelCounterView,
+            chocolateLabel, chocolateCounterView
+        )
+    }
+
+    override func setLayout() {
+        caramelLabel.snp.makeConstraints {
+            $0.top.equalTo(22)
+            $0.leading.equalTo(16)
+        }
+
+        caramelCounterView.snp.makeConstraints {
+            $0.centerY.equalTo(caramelLabel)
+            $0.leading.greaterThanOrEqualTo(caramelLabel.snp.trailing).offset(10)
+            $0.trailing.equalTo(-16)
+            $0.width.equalTo(104)
+            $0.height.equalTo(32)
+        }
+
+        chocolateLabel.snp.makeConstraints {
+            $0.top.equalTo(caramelLabel.snp.bottom).offset(32)
+            $0.leading.equalTo(caramelLabel)
+        }
+
+        chocolateCounterView.snp.makeConstraints {
+            $0.centerY.equalTo(chocolateLabel)
+            $0.leading.greaterThanOrEqualTo(chocolateLabel.snp.trailing).offset(10)
+            $0.bottom.equalTo(-20)
+            $0.trailing.equalTo(caramelCounterView)
+            $0.width.equalTo(104)
+            $0.height.equalTo(32)
+        }
+    }
+}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionDrizzleCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionDrizzleCell.swift
@@ -62,10 +62,10 @@ final class MenuOptionDrizzleCell: BaseTableViewCell {
     override func setStyle() {
         caramelLabel.do {
             $0.setAttributedText(
-                fullText: "카라멜드리즐 (+1에 500원)",
+                fullText: "\(SLMenuOption.caramelDrizzle) \(SLMenuOption.pricePerPlusOne)",
                 styles: [
-                    (text: "카라멜드리즐", font: TSFont.b2s, color: .gray90),
-                    (text: "(+1에 500원)", font: TSFont.c2b, color: .gray60)
+                    (text: SLMenuOption.caramelDrizzle, font: TSFont.b2s, color: .gray90),
+                    (text: SLMenuOption.pricePerPlusOne, font: TSFont.c2b, color: .gray60)
                 ]
             )
 
@@ -74,10 +74,10 @@ final class MenuOptionDrizzleCell: BaseTableViewCell {
 
         chocolateLabel.do {
             $0.setAttributedText(
-                fullText: "초콜릿드리즐 (+1에 500원)",
+                fullText: "\(SLMenuOption.chocolateDrizzle) \(SLMenuOption.pricePerPlusOne)",
                 styles: [
-                    (text: "초콜릿드리즐", font: TSFont.b2s, color: .gray90),
-                    (text: "(+1에 500원)", font: TSFont.c2b, color: .gray60)
+                    (text: SLMenuOption.chocolateDrizzle, font: TSFont.b2s, color: .gray90),
+                    (text: SLMenuOption.pricePerPlusOne, font: TSFont.c2b, color: .gray60)
                 ]
             )
 

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionShotCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionShotCell.swift
@@ -129,3 +129,12 @@ final class MenuOptionShotCell: BaseTableViewCell {
         }
     }
 }
+
+// MARK: - ResetCounterDelegate
+
+extension MenuOptionShotCell: ResetCounterDelegate {
+
+    func resetCounters() {
+        counterView.resetCounter()
+    }
+}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionShotCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionShotCell.swift
@@ -32,15 +32,34 @@ final class MenuOptionShotCell: BaseTableViewCell {
 
     let counterView = CounterView(counterType: .option)
 
+    // MARK: - Properties
+
+    weak var priceDelegate: PriceUpdateDelegate?
+
     // MARK: - Initializer
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
+        updatePriceForCounterChange()
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Actions
+
+    private func updatePriceForCounterChange() {
+        counterView.onValueChanged = { [weak self] count in
+            guard let self = self else { return }
+
+            self.priceDelegate?.priceDidChange(
+                section: 0,
+                itemIndex: 0,
+                count: count
+            )
+        }
     }
 
     // MARK: - UI

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionShotCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionShotCell.swift
@@ -1,0 +1,112 @@
+//
+//  MenuOptionShotCell.swift
+//  TWOSOMEHEART-iOS
+//
+//  Created by RAFA on 11/20/24.
+//
+
+import UIKit
+
+final class MenuOptionShotCell: BaseTableViewCell {
+
+    // MARK: - UI Properties
+
+    private let densityLabel = UILabel()
+
+    private lazy var customSegmentControlView: CustomSegmentControlView = {
+        let buttons = ["기본", "연하게"].map { title in
+            UIButton().then {
+                $0.setTitle(title, for: .normal)
+            }
+        }
+
+        let control = CustomSegmentControlView(
+            buttons: buttons,
+            segmentType: .option
+        )
+
+        return control
+    }()
+
+    private let addShotLabel = UILabel()
+
+    let counterView = CounterView(counterType: .option)
+
+    // MARK: - Initializer
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - UI
+
+    override func setStyle() {
+        densityLabel.do {
+            $0.setLabel(
+                text: "농도",
+                alignment: .left,
+                numberOfLines: 1,
+                textColor: .gray90,
+                font: TSFont.b2s
+            )
+        }
+
+        addShotLabel.do {
+            $0.setAttributedText(
+                fullText: "샷 추가 (+1에 500원)",
+                styles: [
+                    (text: "샷 추가", font: TSFont.b2s, color: .gray90),
+                    (text: "(+1에 500원)", font: TSFont.c2b, color: .gray60)
+                ]
+            )
+
+            $0.textAlignment = .left
+        }
+
+        counterView.do {
+            $0.backgroundColor = .tsWhite
+        }
+    }
+
+    override func setHierarchy() {
+        contentView.addSubviews(
+            densityLabel,
+            customSegmentControlView,
+            addShotLabel,
+            counterView
+        )
+    }
+
+    override func setLayout() {
+        densityLabel.snp.makeConstraints {
+            $0.top.equalTo(16)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        customSegmentControlView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(densityLabel.snp.bottom).offset(5)
+            $0.leading.equalTo(densityLabel)
+            $0.height.equalTo(38)
+        }
+
+        addShotLabel.snp.makeConstraints {
+            $0.top.equalTo(customSegmentControlView.snp.bottom).offset(31)
+            $0.leading.equalTo(customSegmentControlView)
+        }
+
+        counterView.snp.makeConstraints {
+            $0.centerY.equalTo(addShotLabel)
+            $0.leading.greaterThanOrEqualTo(addShotLabel.snp.trailing).offset(10)
+            $0.bottom.equalTo(-25)
+            $0.trailing.equalTo(customSegmentControlView)
+            $0.width.equalTo(104)
+            $0.height.equalTo(32)
+        }
+    }
+}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionShotCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionShotCell.swift
@@ -67,7 +67,7 @@ final class MenuOptionShotCell: BaseTableViewCell {
     override func setStyle() {
         densityLabel.do {
             $0.setLabel(
-                text: "농도",
+                text: SLMenuOption.density,
                 alignment: .left,
                 numberOfLines: 1,
                 textColor: .gray90,
@@ -77,10 +77,10 @@ final class MenuOptionShotCell: BaseTableViewCell {
 
         addShotLabel.do {
             $0.setAttributedText(
-                fullText: "샷 추가 (+1에 500원)",
+                fullText: "\(SLMenuOption.addShot) \(SLMenuOption.pricePerPlusOne)",
                 styles: [
-                    (text: "샷 추가", font: TSFont.b2s, color: .gray90),
-                    (text: "(+1에 500원)", font: TSFont.c2b, color: .gray60)
+                    (text: SLMenuOption.addShot, font: TSFont.b2s, color: .gray90),
+                    (text: SLMenuOption.pricePerPlusOne, font: TSFont.c2b, color: .gray60)
                 ]
             )
 

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionSyrupCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionSyrupCell.swift
@@ -1,0 +1,127 @@
+//
+//  MenuOptionSyrupCell.swift
+//  TWOSOMEHEART-iOS
+//
+//  Created by RAFA on 11/20/24.
+//
+
+import UIKit
+
+final class MenuOptionSyrupCell: BaseTableViewCell {
+
+    // MARK: - UI Properties
+
+    private let vanillaLabel = UILabel()
+    let vanillaCounterView = CounterView(counterType: .option)
+
+    private let hazelLabel = UILabel()
+    let hazelCounterView = CounterView(counterType: .option)
+
+    private let caramelLabel = UILabel()
+    let caramelCounterView = CounterView(counterType: .option)
+
+    // MARK: - Initializer
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - UI
+
+    override func setStyle() {
+        vanillaLabel.do {
+            $0.setAttributedText(
+                fullText: "바닐라시럽 (+1에 500원)",
+                styles: [
+                    (text: "바닐라시럽", font: TSFont.b2s, color: .gray90),
+                    (text: "(+1에 500원)", font: TSFont.c2b, color: .gray60)
+                ]
+            )
+
+            $0.textAlignment = .left
+        }
+
+        hazelLabel.do {
+            $0.setAttributedText(
+                fullText: "헤이즐넛시럽 (+1에 500원)",
+                styles: [
+                    (text: "헤이즐넛시럽", font: TSFont.b2s, color: .gray90),
+                    (text: "(+1에 500원)", font: TSFont.c2b, color: .gray60)
+                ]
+            )
+
+            $0.textAlignment = .left
+        }
+
+        caramelLabel.do {
+            $0.setAttributedText(
+                fullText: "카라멜시럽 (+1에 500원)",
+                styles: [
+                    (text: "카라멜시럽", font: TSFont.b2s, color: .gray90),
+                    (text: "(+1에 500원)", font: TSFont.c2b, color: .gray60)
+                ]
+            )
+
+            $0.textAlignment = .left
+        }
+
+        [vanillaCounterView, hazelCounterView, caramelCounterView].forEach {
+            $0.backgroundColor = .tsWhite
+        }
+    }
+
+    override func setHierarchy() {
+        contentView.addSubviews(
+            vanillaLabel, vanillaCounterView,
+            hazelLabel, hazelCounterView,
+            caramelLabel, caramelCounterView
+        )
+    }
+
+    override func setLayout() {
+        vanillaLabel.snp.makeConstraints {
+            $0.top.equalTo(22)
+            $0.leading.equalTo(16)
+        }
+
+        vanillaCounterView.snp.makeConstraints {
+            $0.centerY.equalTo(vanillaLabel)
+            $0.leading.greaterThanOrEqualTo(vanillaLabel.snp.trailing).offset(10)
+            $0.trailing.equalTo(-16)
+            $0.width.equalTo(104)
+            $0.height.equalTo(32)
+        }
+
+        hazelLabel.snp.makeConstraints {
+            $0.top.equalTo(vanillaLabel.snp.bottom).offset(32)
+            $0.leading.equalTo(vanillaLabel)
+        }
+
+        hazelCounterView.snp.makeConstraints {
+            $0.centerY.equalTo(hazelLabel)
+            $0.leading.greaterThanOrEqualTo(hazelLabel.snp.trailing).offset(10)
+            $0.trailing.equalTo(vanillaCounterView)
+            $0.width.equalTo(104)
+            $0.height.equalTo(32)
+        }
+
+        caramelLabel.snp.makeConstraints {
+            $0.top.equalTo(hazelLabel.snp.bottom).offset(32)
+            $0.leading.equalTo(hazelLabel)
+        }
+
+        caramelCounterView.snp.makeConstraints {
+            $0.centerY.equalTo(caramelLabel)
+            $0.leading.greaterThanOrEqualTo(caramelLabel.snp.trailing).offset(10)
+            $0.bottom.equalTo(-20)
+            $0.trailing.equalTo(hazelCounterView)
+            $0.width.equalTo(104)
+            $0.height.equalTo(32)
+        }
+    }
+}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionSyrupCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionSyrupCell.swift
@@ -116,9 +116,12 @@ final class MenuOptionSyrupCell: BaseTableViewCell {
 
     override func setHierarchy() {
         contentView.addSubviews(
-            vanillaLabel, vanillaCounterView,
-            hazelLabel, hazelCounterView,
-            caramelLabel, caramelCounterView
+            vanillaLabel,
+            vanillaCounterView,
+            hazelLabel,
+            hazelCounterView,
+            caramelLabel,
+            caramelCounterView
         )
     }
 

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionSyrupCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionSyrupCell.swift
@@ -20,15 +20,54 @@ final class MenuOptionSyrupCell: BaseTableViewCell {
     private let caramelLabel = UILabel()
     let caramelCounterView = CounterView(counterType: .option)
 
+    // MARK: - Properties
+
+    weak var priceDelegate: PriceUpdateDelegate?
+
     // MARK: - Initializer
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
+        updatePriceForCounterChange()
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Helpers
+
+    private func updatePriceForCounterChange() {
+        vanillaCounterView.onValueChanged = { [weak self] count in
+            guard let self = self else { return }
+
+            self.priceDelegate?.priceDidChange(
+                section: 1,
+                itemIndex: 0,
+                count: count
+            )
+        }
+
+        hazelCounterView.onValueChanged = { [weak self] count in
+            guard let self = self else { return }
+
+            self.priceDelegate?.priceDidChange(
+                section: 1,
+                itemIndex: 1,
+                count: count
+            )
+        }
+
+        caramelCounterView.onValueChanged = { [weak self] count in
+            guard let self = self else { return }
+
+            self.priceDelegate?.priceDidChange(
+                section: 1,
+                itemIndex: 2,
+                count: count
+            )
+        }
     }
 
     // MARK: - UI

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionSyrupCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionSyrupCell.swift
@@ -125,3 +125,14 @@ final class MenuOptionSyrupCell: BaseTableViewCell {
         }
     }
 }
+
+// MARK: - ResetCounterDelegate
+
+extension MenuOptionSyrupCell: ResetCounterDelegate {
+
+    func resetCounters() {
+        vanillaCounterView.resetCounter()
+        hazelCounterView.resetCounter()
+        caramelCounterView.resetCounter()
+    }
+}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionSyrupCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionSyrupCell.swift
@@ -75,10 +75,10 @@ final class MenuOptionSyrupCell: BaseTableViewCell {
     override func setStyle() {
         vanillaLabel.do {
             $0.setAttributedText(
-                fullText: "바닐라시럽 (+1에 500원)",
+                fullText: "\(SLMenuOption.vanillaSyrup) \(SLMenuOption.pricePerPlusOne)",
                 styles: [
-                    (text: "바닐라시럽", font: TSFont.b2s, color: .gray90),
-                    (text: "(+1에 500원)", font: TSFont.c2b, color: .gray60)
+                    (text: SLMenuOption.vanillaSyrup, font: TSFont.b2s, color: .gray90),
+                    (text: SLMenuOption.pricePerPlusOne, font: TSFont.c2b, color: .gray60)
                 ]
             )
 
@@ -87,10 +87,10 @@ final class MenuOptionSyrupCell: BaseTableViewCell {
 
         hazelLabel.do {
             $0.setAttributedText(
-                fullText: "헤이즐넛시럽 (+1에 500원)",
+                fullText: "\(SLMenuOption.hazelnutSyrup) \(SLMenuOption.pricePerPlusOne)",
                 styles: [
-                    (text: "헤이즐넛시럽", font: TSFont.b2s, color: .gray90),
-                    (text: "(+1에 500원)", font: TSFont.c2b, color: .gray60)
+                    (text: SLMenuOption.hazelnutSyrup, font: TSFont.b2s, color: .gray90),
+                    (text: SLMenuOption.pricePerPlusOne, font: TSFont.c2b, color: .gray60)
                 ]
             )
 
@@ -99,10 +99,10 @@ final class MenuOptionSyrupCell: BaseTableViewCell {
 
         caramelLabel.do {
             $0.setAttributedText(
-                fullText: "카라멜시럽 (+1에 500원)",
+                fullText: "\(SLMenuOption.caramelSyrup) \(SLMenuOption.pricePerPlusOne)",
                 styles: [
-                    (text: "카라멜시럽", font: TSFont.b2s, color: .gray90),
-                    (text: "(+1에 500원)", font: TSFont.c2b, color: .gray60)
+                    (text: SLMenuOption.caramelSyrup, font: TSFont.b2s, color: .gray90),
+                    (text: SLMenuOption.pricePerPlusOne, font: TSFont.c2b, color: .gray60)
                 ]
             )
 

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionWhippedCreamCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionWhippedCreamCell.swift
@@ -66,7 +66,8 @@ final class MenuOptionWhippedCreamCell: BaseTableViewCell {
 
     override func setHierarchy() {
         contentView.addSubviews(
-            whippedCreamLabel, whippedCreamCounterView
+            whippedCreamLabel,
+            whippedCreamCounterView
         )
     }
 

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionWhippedCreamCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionWhippedCreamCell.swift
@@ -49,10 +49,10 @@ final class MenuOptionWhippedCreamCell: BaseTableViewCell {
     override func setStyle() {
         whippedCreamLabel.do {
             $0.setAttributedText(
-                fullText: "휘핑크림 (+1에 500원)",
+                fullText: "\(SLMenuOption.whippedCream) \(SLMenuOption.pricePerPlusOne)",
                 styles: [
-                    (text: "휘핑크림", font: TSFont.b2s, color: .gray90),
-                    (text: "(+1에 500원)", font: TSFont.c2b, color: .gray60)
+                    (text: SLMenuOption.whippedCream, font: TSFont.b2s, color: .gray90),
+                    (text: SLMenuOption.pricePerPlusOne, font: TSFont.c2b, color: .gray60)
                 ]
             )
 

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionWhippedCreamCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionWhippedCreamCell.swift
@@ -1,0 +1,69 @@
+//
+//  MenuOptionWhippedCreamCell.swift
+//  TWOSOMEHEART-iOS
+//
+//  Created by RAFA on 11/20/24.
+//
+
+import UIKit
+
+final class MenuOptionWhippedCreamCell: BaseTableViewCell {
+
+    // MARK: - UI Properties
+
+    private let whippedCreamLabel = UILabel()
+    let whippedCreamCounterView = CounterView(counterType: .option)
+
+    // MARK: - Initializer
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - UI
+
+    override func setStyle() {
+        whippedCreamLabel.do {
+            $0.setAttributedText(
+                fullText: "휘핑크림 (+1에 500원)",
+                styles: [
+                    (text: "휘핑크림", font: TSFont.b2s, color: .gray90),
+                    (text: "(+1에 500원)", font: TSFont.c2b, color: .gray60)
+                ]
+            )
+
+            $0.textAlignment = .left
+        }
+
+        whippedCreamCounterView.do {
+            $0.backgroundColor = .tsWhite
+        }
+    }
+
+    override func setHierarchy() {
+        contentView.addSubviews(
+            whippedCreamLabel, whippedCreamCounterView
+        )
+    }
+
+    override func setLayout() {
+        whippedCreamLabel.snp.makeConstraints {
+            $0.top.equalTo(22)
+            $0.leading.equalTo(16)
+        }
+
+        whippedCreamCounterView.snp.makeConstraints {
+            $0.centerY.equalTo(whippedCreamLabel)
+            $0.leading.greaterThanOrEqualTo(whippedCreamLabel.snp.trailing).offset(10)
+            $0.bottom.equalTo(-20)
+            $0.trailing.equalTo(-16)
+            $0.width.equalTo(104)
+            $0.height.equalTo(32)
+        }
+    }
+}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionWhippedCreamCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionWhippedCreamCell.swift
@@ -67,3 +67,12 @@ final class MenuOptionWhippedCreamCell: BaseTableViewCell {
         }
     }
 }
+
+// MARK: - ResetCounterDelegate
+
+extension MenuOptionWhippedCreamCell: ResetCounterDelegate {
+
+    func resetCounters() {
+        whippedCreamCounterView.resetCounter()
+    }
+}

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionWhippedCreamCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/TableViewCell/MenuOptionWhippedCreamCell.swift
@@ -14,15 +14,34 @@ final class MenuOptionWhippedCreamCell: BaseTableViewCell {
     private let whippedCreamLabel = UILabel()
     let whippedCreamCounterView = CounterView(counterType: .option)
 
+    // MARK: - Properties
+
+    weak var priceDelegate: PriceUpdateDelegate?
+
     // MARK: - Initializer
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
+        updatePriceForCounterChange()
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Helpers
+
+    private func updatePriceForCounterChange() {
+        whippedCreamCounterView.onValueChanged = { [weak self] count in
+            guard let self = self else { return }
+
+            self.priceDelegate?.priceDidChange(
+                section: 2,
+                itemIndex: 0,
+                count: count
+            )
+        }
     }
 
     // MARK: - UI

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/Type/MenuOptionSectionType.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MenuOption/View/Type/MenuOptionSectionType.swift
@@ -1,0 +1,15 @@
+//
+//  MenuOptionSectionType.swift
+//  TWOSOMEHEART-iOS
+//
+//  Created by RAFA on 11/20/24.
+//
+
+import Foundation
+
+enum MenuOptionSectionType: String, CaseIterable {
+    case shot = "샷"
+    case syrup = "시럽"
+    case whippedCream = "휘핑크림"
+    case drizzle = "드리즐"
+}


### PR DESCRIPTION
# 🍋‍🟩 *Pull requests* 🍋‍🟩

## 🍋‍🟩 **작업 브랜치**
- #4 

## 🍋‍🟩 **작업 내용**
<!-- 작업 내용을 적어주세요. -->
- UILabel+에 `setAttributedText` 메서드 추가하였습니다. 다음과 같이 사용할 수 있어요.

```swift
vanillaLabel.do {
    $0.setAttributedText(
        fullText: "바닐라시럽 (+1에 500원)",
        styles: [
            (text: "바닐라시럽", font: TSFont.b2s, color: .gray90),
            (text: "(+1에 500원)", font: TSFont.c2b, color: .gray60)
        ]
    )
}
```
> 결과
![스크린샷 2024-11-20 23 33 08](https://github.com/user-attachments/assets/59c62427-27a1-45af-9c15-cb8bd6b91f6c)

- BaseTableViewCell 추가하였습니다. BaseViewController처럼 사용하시면 됩니다.
- setStackView 메서드에 spacing 오타 및 타입 수정하였습니다. 그리고 spacing 기본값 0으로 설정하였습니다.

```swift
func setStackView(axis: NSLayoutConstraint.Axis = .horizontal,
                  distribution: UIStackView.Distribution = .fillEqually,
                  alignment: UIStackView.Alignment = .fill,
                  spacing: CGFloat = 0) {
    self.axis = axis
    self.distribution = distribution
    self.alignment = alignment
    self.spacing = spacing
    self.translatesAutoresizingMaskIntoConstraints = false
}
```

- CounterView에 `var onValueChanged: ((Int) -> Void)?`랑 `func resetCounter()` 메서드 추가하였습니다.
- `onValueChanged`는 메뉴 옵션 수량 변경 시 가격을 업데이트하기 위해 작성하였습니다.
- `resetCounter` 메서드는 수량을 모두 초기화하기 위해 작성하였습니다.

## 🚨 참고 사항
<!-- 참고사항이 있다면 적어주세요. -->
- Convert to Folder 상태일 때(파란색 폴더)는 파일 및 폴더가 자유롭게 이동할 수 없어 Convert to Group으로 변경하였습니다.

| Convert to Folder | Convert to Group |
| -- | -- |
| ![스크린샷 2024-11-20 23 27 22](https://github.com/user-attachments/assets/1bc16e17-30a3-4f18-9313-ea9c0a19ca93) | ![스크린샷 2024-11-20 23 27 31](https://github.com/user-attachments/assets/8d538185-c361-40c8-b177-5a15f5390e8c) |

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰16|![Simulator Screen Recording - iPhone 16 - 2024-11-21 at 17 13 31](https://github.com/user-attachments/assets/b2c7df80-49db-48b6-ab3d-5687a97e1acf)|

## 🍋‍🟩 이슈
- Resolved: #4 