### PR TITLE
[FEAT] 마이 메뉴 즐겨찾기 목록 API 연동 (#29)

### DIFF
--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Utils/Aliases.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Utils/Aliases.swift
@@ -14,3 +14,4 @@ typealias SLMenu = StringLiterals.MenuType
 typealias SLNavBar = StringLiterals.NavigationBarType
 typealias SLSelectedStore = StringLiterals.SelectedStoreType
 typealias SLModal = StringLiterals.ModalType
+typealias SLMyMenu = StringLiterals.MyMenuType

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Utils/StringLiterals.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Utils/StringLiterals.swift
@@ -111,6 +111,9 @@ enum StringLiterals {
         
         static let goOrder = "주문하기"
         
+        static let personalCup = "개인컵"
+        
+        static let noReuseCup = "일회용컵"
     }
 
     enum MenuOptionType {

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Utils/StringLiterals.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/Utils/StringLiterals.swift
@@ -14,6 +14,8 @@ enum StringLiterals {
         static let title = "투썸오더"
         
         static let detail = "커피/음료"
+        
+        static let myMenu = "My 투썸"
 
     }
 

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Network/DTO/Response/DTO+GetLikedMenuResponse.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Network/DTO/Response/DTO+GetLikedMenuResponse.swift
@@ -10,10 +10,13 @@ import Foundation
 extension DTO {
     
     struct GetLikedMenuResponse: Codable {
-        let code: Int
-        let data: [FavoriteList]?
+        let status: Int
+        let data: GetLikedMenuData?
     }
     
+    struct GetLikedMenuData: Codable {
+        let favoriteList: [DTO.GetLikedMenuResponse.FavoriteList]
+    }
 }
 
 extension DTO.GetLikedMenuResponse {
@@ -22,23 +25,28 @@ extension DTO.GetLikedMenuResponse {
         let id: Int
         let name: String
         let price: Int
-        let imageURL: String
-        let temperature: Int
-        let size: Int
-        let coffeeBean: Int
-        let togo: Int
+        let imageUrl: String
+        let temperature: String
+        let size: String
+        let coffeeBean: String
+        let togo: String
         let personal: Bool?
         
         private enum CodingKeys: String, CodingKey {
             case id
             case name
             case price
-            case imageURL = "image_url"
+            case imageUrl = "imageUrl"
             case temperature
             case size
             case coffeeBean
             case togo
             case personal
+        }
+        
+        var formattedOptions: String {
+            let personalCup = personal == true ? "개인컵" : "일회용컵"
+            return "\(temperature)/\(size)/\(coffeeBean)/\(togo)/\(personalCup)"
         }
     }
     

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Network/DTO/Response/DTO+GetLikedMenuResponse.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Network/DTO/Response/DTO+GetLikedMenuResponse.swift
@@ -45,7 +45,7 @@ extension DTO.GetLikedMenuResponse {
         }
         
         var formattedOptions: String {
-            let personalCup = personal == true ? "개인컵" : "일회용컵"
+            let personalCup = personal == true ? SLMyMenu.personalCup : SLMyMenu.noReuseCup
             return "\(temperature)/\(size)/\(coffeeBean)/\(togo)/\(personalCup)"
         }
     }

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/Menu/Controller/MenuViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/Menu/Controller/MenuViewController.swift
@@ -29,6 +29,7 @@ final class MenuViewController: BaseNavViewController {
         setDelegates()
         registerCells()
         configureNavigationBarStyle()
+        setAddTargets()
     }
 
     // MARK: - Helpers
@@ -40,6 +41,15 @@ final class MenuViewController: BaseNavViewController {
 
     private func registerCells() {
         tableView.register(MenuCell.self, forCellReuseIdentifier: MenuCell.identifier)
+    }
+    
+    private func setAddTargets(){
+        myButton.addTarget(self, action: #selector(myButtonTapped), for: .touchUpInside)
+    }
+    
+    @objc private func myButtonTapped() {
+        let myMenuVC = MyMenuViewController()
+        navigationController?.pushViewController(myMenuVC, animated: true)
     }
 
     // MARK: - UI

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/Controller/MyMenuViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/Controller/MyMenuViewController.swift
@@ -26,7 +26,12 @@ class MyMenuViewController: BaseNavViewController {
     
     // MARK: - Properties
     
-    private var likedItems: [DTO.GetLikedMenuResponse.FavoriteList] = []
+    private var likedItems: [DTO.GetLikedMenuResponse.FavoriteList] = [] {
+        didSet {
+            myMenuHeaderView.likedItemsCount = likedItems.count
+        }
+    }
+
     private var service: NetworkService<APITarget.Likes>?
     var selectedIndexes: Set<Int> = []
     
@@ -280,8 +285,11 @@ extension MyMenuViewController: MyMenuHeaderViewDelegate {
             selectedIndexes.removeAll()
         }
         
+        print("총 아이템 수: \(likedItems.count), 선택된 인덱스 수: \(selectedIndexes.count)")
+        
         for index in 0..<likedItems.count {
             if let cell = myMenuCollectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? MyMenuCollectionViewCell {
+                print(cell, index)
                 cell.setCheckboxSelected(isSelected)
             }
         }

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/Controller/MyMenuViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/Controller/MyMenuViewController.swift
@@ -31,7 +31,7 @@ class MyMenuViewController: BaseNavViewController {
             myMenuHeaderView.likedItemsCount = likedItems.count
         }
     }
-
+    
     private var service: NetworkService<APITarget.Likes>?
     var selectedIndexes: Set<Int> = []
     
@@ -285,15 +285,13 @@ extension MyMenuViewController: MyMenuHeaderViewDelegate {
             selectedIndexes.removeAll()
         }
         
-        print("총 아이템 수: \(likedItems.count), 선택된 인덱스 수: \(selectedIndexes.count)")
-        
         for index in 0..<likedItems.count {
             if let cell = myMenuCollectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? MyMenuCollectionViewCell {
                 print(cell, index)
                 cell.setCheckboxSelected(isSelected)
             }
         }
-
+        
         selectedIndexes.isEmpty ? hideModal() : showModal()
     }
 }

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/Controller/MyMenuViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/Controller/MyMenuViewController.swift
@@ -36,6 +36,7 @@ class MyMenuViewController: BaseNavViewController {
         super.viewDidLoad()
         
         setAddTargets()
+        setDelegates()
         setCollectionView()
         setModal()
         setNavigationBarStyle()
@@ -58,6 +59,10 @@ class MyMenuViewController: BaseNavViewController {
             action: #selector(deleteButtonTapped),
             for: .touchUpInside
         )
+    }
+    
+    private func setDelegates(){
+        myMenuHeaderView.delegate = self
     }
     
     // MARK: - UI
@@ -264,6 +269,25 @@ extension MyMenuViewController: UICollectionViewDropDelegate {
     }
     
     
+}
+
+// MARK: - MyMenuHeaderView Delegate
+extension MyMenuViewController: MyMenuHeaderViewDelegate {
+    func selectAllCheckboxTapped(isSelected: Bool) {
+        if isSelected {
+            selectedIndexes = Set(0..<likedItems.count)
+        } else {
+            selectedIndexes.removeAll()
+        }
+        
+        for index in 0..<likedItems.count {
+            if let cell = myMenuCollectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? MyMenuCollectionViewCell {
+                cell.setCheckboxSelected(isSelected)
+            }
+        }
+
+        selectedIndexes.isEmpty ? hideModal() : showModal()
+    }
 }
 
 

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/Cell/MyMenuCollectionViewCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/Cell/MyMenuCollectionViewCell.swift
@@ -179,4 +179,8 @@ class MyMenuCollectionViewCell: UICollectionViewCell {
         checkboxButton.isSelected = isSelectedCheckbox
         delegate?.checkboxTapped(at: index, isSelected: isSelectedCheckbox)
     }
+    
+    func setCheckboxSelected(_ isSelected: Bool) {
+        checkboxButton.isSelected = isSelected
+    }
 }

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/Cell/MyMenuCollectionViewCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/Cell/MyMenuCollectionViewCell.swift
@@ -159,11 +159,13 @@ class MyMenuCollectionViewCell: UICollectionViewCell {
     }
     
     // MARK: - Bind
-    func bind(_ myMenuItem: MyMenuItem){
-        menuImageView.image = myMenuItem.menuImage
+    func bind(_ myMenuItem: DTO.GetLikedMenuResponse.FavoriteList){
+        if let imageURL = URL(string: myMenuItem.imageUrl) {
+            menuImageView.kf.setImage(with: imageURL)
+        }
         menuNameLabel.text = myMenuItem.name
         menuPriceLabel.text = "\(myMenuItem.price.formattedPrice())원"
-        menuOptionsLabel.text = myMenuItem.options.joined(separator: "/")
+        menuOptionsLabel.text = myMenuItem.formattedOptions
     }
     
     func configure(with index: Int) {

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/MyMenuHeaderView.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/MyMenuHeaderView.swift
@@ -10,6 +10,10 @@ import UIKit
 import SnapKit
 import Then
 
+protocol MyMenuHeaderViewDelegate: AnyObject {
+    func selectAllCheckboxTapped(isSelected: Bool)
+}
+
 class MyMenuHeaderView: UIView {
     // MARK: - UI Properties
     
@@ -21,7 +25,8 @@ class MyMenuHeaderView: UIView {
     
     // MARK: Properties
     private var isAllSelected: Bool = false
-    
+    weak var delegate: MyMenuHeaderViewDelegate?
+
     // MARK: - Initializer
     
     override init(frame: CGRect) {
@@ -133,5 +138,6 @@ class MyMenuHeaderView: UIView {
     @objc private func selectAllCheckboxTapped() {
         isAllSelected.toggle()
         selectAllCheckbox.isSelected = isAllSelected
+        delegate?.selectAllCheckboxTapped(isSelected: isAllSelected)
     }
 }

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/MyMenuHeaderView.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/MyMenuHeaderView.swift
@@ -26,6 +26,11 @@ class MyMenuHeaderView: UIView {
     // MARK: Properties
     private var isAllSelected: Bool = false
     weak var delegate: MyMenuHeaderViewDelegate?
+    var likedItemsCount: Int = 0 {
+         didSet {
+             updateTotalQuantityLabel()
+         }
+     }
 
     // MARK: - Initializer
     
@@ -43,31 +48,6 @@ class MyMenuHeaderView: UIView {
     // MARK: - Style, UI, Layout
     
     private func setStyle() {
-        totalQuantityLabel.do {
-            let fullText = "총 3개"
-            let attributedString = NSMutableAttributedString(string: fullText)
-            
-            let totalText = (fullText as NSString).range(of: "총")
-            attributedString.addAttributes([
-                .font: TSFont.c2r,
-                .foregroundColor: UIColor(resource: .gray90)
-            ], range: totalText)
-            
-            let countText = (fullText as NSString).range(of: "3")
-            attributedString.addAttributes([
-                .font: TSFont.c2b,
-                .foregroundColor: UIColor(resource: .gray90)
-            ], range: countText)
-            
-            let unitText = (fullText as NSString).range(of: "개")
-            attributedString.addAttributes([
-                .font: TSFont.c2r,
-                .foregroundColor: UIColor(resource: .gray90)
-            ], range: unitText)
-            
-            $0.attributedText = attributedString
-        }
-        
         selectAllCheckbox.do {
             $0.setImage(UIImage(resource: .modalCheckboxDeselect), for: .normal)
             $0.setImage(UIImage(resource: .mymenuCheckboxSelect), for: .selected)
@@ -139,5 +119,17 @@ class MyMenuHeaderView: UIView {
         isAllSelected.toggle()
         selectAllCheckbox.isSelected = isAllSelected
         delegate?.selectAllCheckboxTapped(isSelected: isAllSelected)
+    }
+    
+    private func updateTotalQuantityLabel() {
+        let fullText = "총 \(likedItemsCount)개"
+        
+        let styles: [(text: String, font: UIFont, color: UIColor)] = [
+            (text: "총", font: TSFont.c2r, color: UIColor(resource: .gray90)),
+            (text: "\(likedItemsCount)", font: TSFont.c2b, color: UIColor(resource: .gray90)),
+            (text: "개", font: TSFont.c2r, color: UIColor(resource: .gray90))
+        ]
+    
+        totalQuantityLabel.setAttributedText(fullText: fullText, styles: styles)
     }
 }

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/MyMenuModalView.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/MyMenuModalView.swift
@@ -51,7 +51,7 @@ class MyMenuModalView: UIView {
         }
         
         storeNameLabel.do {
-            $0.text = StringLiterals.MyMenuType.orderStore
+            $0.text = StringLiterals.MyMenuType.storeName
             $0.font = TSFont.t1b
             $0.textColor = UIColor(resource: .tsBlack)
         }


### PR DESCRIPTION
# 🍋‍🟩 *Pull requests* 🍋‍🟩

## 🍋‍🟩 **작업 브랜치**
- #29 

## 🍋‍🟩 **작업 내용**
- 마이메뉴 페이지 즐겨찾기 목록 API 연동 작업했습니다.

## 🚨 참고 사항
- 이전 PR과 같은 이슈로 service 를 클래스 레벨에서 선언해서 사용하였습니다! (나중에 리팩 할 때 원인 찾고 수정해보겠습니다..!) 

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰16|<img src = "https://github.com/user-attachments/assets/414a1998-c106-4334-9984-9c897a1f97ae" width ="250">|



## 🍋‍🟩 이슈
- Resolved: #29 
