### PR TITLE
[FEAT] 즐겨찾기 목록 삭제 API 연동 (#30)

### DIFF
--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/UIComponents/CustomAlertViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/UIComponents/CustomAlertViewController.swift
@@ -21,6 +21,7 @@ final class CustomAlertViewController: BaseViewController {
     
     private let isAllChecked: Bool
     private let checkedMenuList: Set<Int>
+    var completion: (() -> Void)?
     
     // MARK: - Lifecycle
 
@@ -48,7 +49,9 @@ final class CustomAlertViewController: BaseViewController {
 
     @objc private func confirmButtonTapped() {
         deleteLikedMenu()
-        dismiss(animated: false)
+        dismiss(animated: true) { [weak self] in
+            self?.completion?()
+        }
     }
 
     // MARK: - Helpers

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/UIComponents/CustomAlertViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Global/UIComponents/CustomAlertViewController.swift
@@ -18,9 +18,22 @@ final class CustomAlertViewController: BaseViewController {
     private let buttonCenterSeparatorView = UIView()
     private let confirmButton = UIButton(type: .system)
     private let alertButtonStackView = UIStackView()
-
+    
+    private let isAllChecked: Bool
+    private let checkedMenuList: Set<Int>
+    
     // MARK: - Lifecycle
 
+    init(isAllChecked: Bool, checkedMenuList: Set<Int>) {
+        self.isAllChecked = isAllChecked
+        self.checkedMenuList = checkedMenuList
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -34,6 +47,7 @@ final class CustomAlertViewController: BaseViewController {
     }
 
     @objc private func confirmButtonTapped() {
+        deleteLikedMenu()
         dismiss(animated: false)
     }
 
@@ -137,4 +151,25 @@ final class CustomAlertViewController: BaseViewController {
             $0.bottom.equalTo(alertView.snp.bottom)
         }
     }
+}
+
+private extension CustomAlertViewController {
+
+    func deleteLikedMenu() {
+        let service = NetworkService<APITarget.Likes>()
+        let all = isAllChecked ? "true" : "false"
+        let favoriteIds = checkedMenuList.map { String($0) }.joined(separator: ",")
+
+        let request = DTO.DeleteLikedMenuRequest(favoriteIds: favoriteIds, all: all)
+        service.provider.request(.deleteLikedMenu(request)) { [weak self] response in
+            switch response {
+            case .success(let response):
+                print("🍀🍀🍀서버 통신 성공🍀🍀🍀")
+                return
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+    
 }

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Network/APITarget/APITarget+Likes.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Network/APITarget/APITarget+Likes.swift
@@ -39,11 +39,17 @@ extension APITarget.Likes: TargetType {
         case .getLikedMenu:
             return .requestPlain
         case .deleteLikedMenu(let deleteInfoMenuRequest):
-            return .requestParameters(
-                parameters: ["favoriteIds": deleteInfoMenuRequest.favoriteIds,
-                             "all": deleteInfoMenuRequest.all],
-                encoding: URLEncoding.default
-            )
+            if deleteInfoMenuRequest.all == "true" {
+                return .requestParameters(
+                    parameters: ["all": deleteInfoMenuRequest.all],
+                    encoding: URLEncoding.queryString
+                )
+            } else {
+                return .requestParameters(
+                    parameters: ["favoriteIds": deleteInfoMenuRequest.favoriteIds],
+                    encoding: URLEncoding.queryString
+                )
+            }
         }
     }
 

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Network/DTO/Request/DTO+DeleteLikedMenuRequest.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Network/DTO/Request/DTO+DeleteLikedMenuRequest.swift
@@ -10,8 +10,8 @@ import Foundation
 extension DTO {
     
     struct DeleteLikedMenuRequest: Codable {
-        let favoriteIds: String?
-        let all: String?
+        let favoriteIds: String
+        let all: String
     }
     
 }

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/Controller/MyMenuViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/Controller/MyMenuViewController.swift
@@ -34,6 +34,7 @@ class MyMenuViewController: BaseNavViewController {
     
     private var service: NetworkService<APITarget.Likes>?
     var selectedIndexes: Set<Int> = []
+    var allCheckBoxSelected: Bool = false
     
     // MARK: - LifeCycle
     
@@ -51,7 +52,8 @@ class MyMenuViewController: BaseNavViewController {
     // MARK: - Actions
     
     @objc private func deleteButtonTapped() {
-        let alertVC = CustomAlertViewController()
+        let alertVC = CustomAlertViewController(isAllChecked: allCheckBoxSelected,
+                                                checkedMenuList: selectedIndexes)
         alertVC.modalPresentationStyle = .custom
         present(alertVC, animated: false)
     }
@@ -282,8 +284,10 @@ extension MyMenuViewController: MyMenuHeaderViewDelegate {
     func selectAllCheckboxTapped(isSelected: Bool) {
         if isSelected {
             selectedIndexes = Set(0..<likedItems.count)
+            allCheckBoxSelected = true
         } else {
             selectedIndexes.removeAll()
+            allCheckBoxSelected = false
         }
         
         for index in 0..<likedItems.count {
@@ -330,6 +334,4 @@ private extension MyMenuViewController {
         }
     }
 }
-
-
 

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/Controller/MyMenuViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/Controller/MyMenuViewController.swift
@@ -58,11 +58,12 @@ class MyMenuViewController: BaseNavViewController {
         alertVC.modalPresentationStyle = .custom
         alertVC.completion = { [weak self] in
             Task {
+                self?.hideModal()
+                self?.myMenuHeaderView.selectAllCheckbox.isSelected = false
                 try? await self?.fetchLikedMenuList()
                 self?.myMenuCollectionView.reloadData()
                 self?.selectedIndexes.removeAll()
                 self?.selectedIds.removeAll()
-                self?.allCheckBoxSelected = false
             }
         }
         present(alertVC, animated: false)

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/Controller/MyMenuViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/Controller/MyMenuViewController.swift
@@ -34,6 +34,7 @@ class MyMenuViewController: BaseNavViewController {
     
     private var service: NetworkService<APITarget.Likes>?
     var selectedIndexes: Set<Int> = []
+    var selectedIds: Set<Int> = []
     var allCheckBoxSelected: Bool = false
     
     // MARK: - LifeCycle
@@ -53,7 +54,7 @@ class MyMenuViewController: BaseNavViewController {
     
     @objc private func deleteButtonTapped() {
         let alertVC = CustomAlertViewController(isAllChecked: allCheckBoxSelected,
-                                                checkedMenuList: selectedIndexes)
+                                                checkedMenuList: selectedIds)
         alertVC.modalPresentationStyle = .custom
         present(alertVC, animated: false)
     }
@@ -202,8 +203,10 @@ extension MyMenuViewController: MyMenuCollectionViewCellDelegate {
     func checkboxTapped(at index: Int, isSelected: Bool) {
         if isSelected {
             selectedIndexes.insert(index)
+            selectedIds.insert(likedItems[index].id)
         } else {
             selectedIndexes.remove(index)
+            selectedIds.remove(likedItems[index].id)
         }
         
         selectedIndexes.isEmpty ? hideModal() : showModal()
@@ -285,9 +288,13 @@ extension MyMenuViewController: MyMenuHeaderViewDelegate {
         if isSelected {
             selectedIndexes = Set(0..<likedItems.count)
             allCheckBoxSelected = true
+            for i in selectedIndexes {
+                selectedIds.insert(likedItems[i].id)
+            }
         } else {
             selectedIndexes.removeAll()
             allCheckBoxSelected = false
+            selectedIds.removeAll()
         }
         
         for index in 0..<likedItems.count {

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/Controller/MyMenuViewController.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/Controller/MyMenuViewController.swift
@@ -56,6 +56,15 @@ class MyMenuViewController: BaseNavViewController {
         let alertVC = CustomAlertViewController(isAllChecked: allCheckBoxSelected,
                                                 checkedMenuList: selectedIds)
         alertVC.modalPresentationStyle = .custom
+        alertVC.completion = { [weak self] in
+            Task {
+                try? await self?.fetchLikedMenuList()
+                self?.myMenuCollectionView.reloadData()
+                self?.selectedIndexes.removeAll()
+                self?.selectedIds.removeAll()
+                self?.allCheckBoxSelected = false
+            }
+        }
         present(alertVC, animated: false)
     }
     

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/Cell/MyMenuCollectionViewCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/Cell/MyMenuCollectionViewCell.swift
@@ -22,6 +22,7 @@ class MyMenuCollectionViewCell: UICollectionViewCell {
     private var index: Int = 0
     private var isSelectedCheckbox = false
     private var myMenuItems: MyMenuItem?
+    private var id : Int = 0
     
     // MARK: - Components
     private lazy var checkboxButton = UIButton(type: .custom)
@@ -166,6 +167,7 @@ class MyMenuCollectionViewCell: UICollectionViewCell {
         menuNameLabel.text = myMenuItem.name
         menuPriceLabel.text = "\(myMenuItem.price.formattedPrice())원"
         menuOptionsLabel.text = myMenuItem.formattedOptions
+        self.id = myMenuItem.id
     }
     
     func configure(with index: Int) {

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/Cell/MyMenuCollectionViewCell.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/Cell/MyMenuCollectionViewCell.swift
@@ -47,6 +47,12 @@ class MyMenuCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        checkboxButton.isSelected = false
+    }
+    
     // MARK: - Style, UI, Layout
     private func setStyle(){
         checkboxButton.do {

--- a/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/MyMenuHeaderView.swift
+++ b/TWOSOMEHEART-iOS/TWOSOMEHEART-iOS/Presentation/MyMenuView/View/MyMenuHeaderView.swift
@@ -18,7 +18,7 @@ class MyMenuHeaderView: UIView {
     // MARK: - UI Properties
     
     private let totalQuantityLabel = UILabel()
-    private let selectAllCheckbox = UIButton(type: .custom)
+    let selectAllCheckbox = UIButton(type: .custom)
     private let selectAllLabel = UILabel()
     let deleteButton = UIButton()
     private let separatorLine = UIView()


### PR DESCRIPTION
# 🍋‍🟩 *Pull requests* 🍋‍🟩

## 🍋‍🟩 **작업 브랜치**
- #30

## 🍋‍🟩 **작업 내용**
즐겨찾기 메뉴 삭제 API 연동 및 삭제 후 즐겨찾기 메뉴가 바로 업데이트되도록 했습니다.

## 🚨 참고 사항


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰16|<img src = "https://github.com/user-attachments/assets/2613bdca-8052-4061-93f3-6e016bd21512" width ="250">|


## 🍋‍🟩 이슈
- Resolved: #30
